### PR TITLE
Implements a wrapper around stdin on the Windows platform to provide standard ANSI events

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#62021A",
+        "titleBar.activeBackground": "#890225",
+        "titleBar.activeForeground": "#FFFBFC"
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
-# 0.1.0
+# Nocterm Changes log
 
-## Breaking Changes
+## 0.1.1
+
+- Provide wrapper for Window's platform's terminal`stdin` so that it behaves as a 'standard' unix style terminal in
+  regards to sending mouse and keyboard key events as ANSI CSI sequences.
+  
+## 0.1.0
+
+### Breaking Changes
 
 ### ListView
+
 - **BREAKING**: Removed automatic keyboard navigation from ListView. Applications must now manually wrap ListView in Focusable for keyboard support:
+
   ```dart
   // Before (0.0.1)
   ListView(children: [...])
@@ -16,44 +25,52 @@
   ```
 
 ### TextField
+
 - **BREAKING**: Removed automatic tap-to-focus behavior. Manual focus management now required for tap interactions.
 
-## Major Features
+### Major Features
 
-### State Management
+#### State Management
+
 - **Riverpod Integration**: Complete Riverpod state management with ProviderScope, reactive widgets, and full provider API support
 - **Render Theater**: New overlay management system with optimized paint ordering and hit testing
 - **Provider Dependencies**: Sophisticated subscription management for reactive UI updates
 
-### UI Components
+#### UI Components
+
 - **Stack Widget**: Overlapping layout support with positioned/non-positioned children
 - **ConstrainedBox**: Min/max width/height constraints for precise layout control
 - **Markdown Support**: Rich text rendering with headers, lists, code blocks, tables, and links
 
-### Navigation
+#### Navigation
+
 - **Overlay System**: Complete navigator rewrite using overlay-based architecture
 - **Route Replacement**: New pushReplacement methods for better navigation flow
 - **Navigator Improvements**: Enhanced route management and lifecycle handling
 
-## Performance Improvements
+#### Performance Improvements
+
 - **Terminal Output**: Write buffering dramatically reduces system calls
 - **ListView CPU Fix**: Fixed 100% CPU usage with proper change detection
 - **Event Processing**: Eliminated keyboard event spam from unparseable mouse events
 - **Performance Tests**: Added benchmark suite for regression testing
 
-## Scrolling Enhancements
+#### Scrolling Enhancements
+
 - **RenderObject Scrolling**: Moved scrolling logic to RenderObject layer for better performance
 - **Mouse Support**: Full mouse wheel scrolling with SGR coordinate tracking
 - **Auto-Scroll**: Smart auto-scrolling for chat/log interfaces
 - **Reverse Mode**: ListView reverse option for chat-like UIs
 - **Improved Metrics**: Better scroll extent calculation for variable-height items
 
-## Visual Improvements
+#### Visual Improvements
+
 - **Modern Colors**: Updated color palette with sophisticated muted tones
 - **Cursor Styles**: Enhanced text field cursor customization
 - **Text Wrapping**: Proper text wrapping in columns with cross-axis stretch
 
-## Bug Fixes
+#### Bug Fixes
+
 - Fixed multi-child rebuild layout issues
 - Fixed column-in-column constraint handling
 - Fixed render object handling for Expanded widgets
@@ -62,13 +79,13 @@
 - Fixed constraints in flexible layouts and Align widgets
 - Improved error handling and hot reload logging
 
-## Architecture
+#### Architecture
+
 - Clean separation of display and input concerns
 - Enhanced lifecycle management for components
 - Improved render object system with better layout calculations
 - Comprehensive test coverage with visual validation
 
-
-# 0.0.1
+## 0.0.1
 
 - Initial version.

--- a/lib/nocterm.dart
+++ b/lib/nocterm.dart
@@ -3,6 +3,7 @@ export 'src/backend/terminal.dart';
 export 'src/buffer.dart';
 export 'src/frame.dart';
 export 'src/style.dart';
+export 'src/win32_ansi_stdin.dart';
 export 'src/components/progress_bar.dart';
 export 'src/components/scrollbar.dart';
 export 'src/test/nocterm_tester.dart';

--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -7,6 +7,7 @@ import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:nocterm/src/navigation/render_theater.dart';
 import 'package:nocterm/src/rectangle.dart';
 import 'package:nocterm/src/rendering/scrollable_render_object.dart';
+import 'package:nocterm/src/win32_ansi_stdin.dart';
 
 import '../backend/terminal.dart' as term;
 import '../buffer.dart' as buf;
@@ -18,7 +19,7 @@ import 'hot_reload_mixin.dart';
 
 /// Terminal UI binding that handles terminal input/output and event loop
 class TerminalBinding extends NoctermBinding with HotReloadBinding {
-  TerminalBinding(this.terminal) {
+  TerminalBinding(this.terminal, { this.logSink}) {
     _instance = this;
     _initializePipelineOwner();
   }
@@ -27,6 +28,7 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
   static TerminalBinding get instance => _instance!;
 
   final term.Terminal terminal;
+  final IOSink? logSink;
   PipelineOwner? _pipelineOwner;
   PipelineOwner get pipelineOwner => _pipelineOwner!;
 
@@ -96,12 +98,14 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
     _startSignalHandling();
   }
 
+  final Stdin platformStdin = Platform.isWindows ? Win32AnsiStdin() : stdin;
+
   void _startInputHandling() {
     // Only set stdin mode if we have a terminal
     try {
-      if (stdin.hasTerminal) {
-        stdin.echoMode = false;
-        stdin.lineMode = false;
+      if (platformStdin.hasTerminal) {
+        platformStdin.echoMode = false;
+        platformStdin.lineMode = false;
       }
     } catch (e) {
       // Ignore errors when running without a proper terminal
@@ -109,14 +113,22 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
     }
 
     // Listen for input at the byte level for proper escape sequence handling
-    _inputSubscription = stdin.listen((bytes) {
+    _inputSubscription = platformStdin.listen((bytes) {
       // Parse the bytes and process ALL events in the buffer
       _inputParser.addBytes(bytes);
+  
+      // For debugging, show raw input (replace ESC and ENTER for visibility)
+      final data = utf8.decode(bytes);
+      final visual = data.replaceAll('\x1b', 'ESC').replaceAll('\r', 'ENTER\n');
+      logSink?.writeln('RAW Received: $visual');
 
       // Process all available events
       InputEvent? inputEvent;
       while ((inputEvent = _inputParser.parseNext()) != null) {
         if (inputEvent is KeyboardInputEvent) {
+
+          logSink?.writeln('KeyboardInputEvent: ${inputEvent.event}');
+
           final event = inputEvent.event;
           // Add to keyboard event stream
           _keyboardEventController.add(event);
@@ -134,6 +146,10 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
           // Note: Ctrl+C is handled by SIGINT signal handler, not here
           // This prevents double-handling and ensures proper cleanup
         } else if (inputEvent is MouseInputEvent) {
+
+          logSink?.writeln('MouseInputEvent: ${inputEvent.event}');
+
+  
           final event = inputEvent.event;
           // Add to mouse event stream
           _mouseEventController.add(event);
@@ -172,7 +188,7 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
 
   void _startSignalHandling() {
     // Listen for termination signals to ensure cleanup runs
-    if (Platform.isLinux || Platform.isMacOS) {
+    if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
       // Handle SIGINT (Ctrl+C)
       _sigintSubscription = ProcessSignal.sigint.watch().listen((_) {
         // Perform cleanup synchronously
@@ -182,7 +198,8 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
         // This ensures single Ctrl+C quits the app
         exit(0);
       });
-
+    }
+    if (Platform.isLinux || Platform.isMacOS) {
       // Handle SIGTERM (kill command)
       _sigtermSubscription = ProcessSignal.sigterm.watch().listen((_) {
         // Perform cleanup synchronously
@@ -199,6 +216,11 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
     // Prevent multiple shutdowns
     if (_shouldExit) return;
     _shouldExit = true;
+
+    // if we are using the win32 stdin, close it
+    if (platformStdin is Win32AnsiStdin) {
+      (platformStdin as Win32AnsiStdin).close();
+    }
 
     // Cancel all timers and subscriptions immediately
     _frameTimer?.cancel();
@@ -240,9 +262,9 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
       terminal.clear();
 
       // Restore stdin
-      if (stdin.hasTerminal) {
-        stdin.echoMode = true;
-        stdin.lineMode = true;
+      if (platformStdin.hasTerminal) {
+        platformStdin.echoMode = true;
+        platformStdin.lineMode = true;
       }
     } catch (_) {
       // Ignore any errors during cleanup
@@ -522,9 +544,9 @@ class TerminalBinding extends NoctermBinding with HotReloadBinding {
 
     // Restore stdin if we have a terminal
     try {
-      if (stdin.hasTerminal) {
-        stdin.echoMode = true;
-        stdin.lineMode = true;
+      if (platformStdin.hasTerminal) {
+        platformStdin.echoMode = true;
+        platformStdin.lineMode = true;
       }
     } catch (e) {
       // Ignore errors when running without a proper terminal
@@ -659,7 +681,7 @@ Future<void> runApp(Component app, {bool enableHotReload = true}) async {
   try {
     await runZoned(() async {
       final terminal = term.Terminal();
-      binding = TerminalBinding(terminal);
+      binding = TerminalBinding(terminal, logSink: logSink);
 
       binding!.initialize();
       binding!.attachRootComponent(app);

--- a/lib/src/keyboard/input_parser.dart
+++ b/lib/src/keyboard/input_parser.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+import 'package:nocterm/nocterm.dart' show TerminalBinding;
+
 import 'logical_key.dart';
 import 'keyboard_event.dart';
 import 'mouse_parser.dart';
@@ -270,6 +272,9 @@ class InputParser {
   }
 
   KeyboardEvent? _parseCSISequence() {
+
+    TerminalBinding.instance.logSink?.writeln('_parseCSISequence _buffer: $_buffer');
+
     // Skip mouse sequences - they're handled elsewhere
     if (_buffer.length >= 3 && (_buffer[2] == 0x3C || _buffer[2] == 0x4D)) {
       return null;
@@ -278,37 +283,37 @@ class InputParser {
     // Arrow keys: ESC [ A/B/C/D
     if (_buffer.length == 3) {
       switch (_buffer[2]) {
-        case 0x41:
+        case 0x41: // A
           return KeyboardEvent(
             logicalKey: LogicalKey.arrowUp,
             modifiers: const ModifierKeys(),
           );
-        case 0x42:
+        case 0x42: // B
           return KeyboardEvent(
             logicalKey: LogicalKey.arrowDown,
             modifiers: const ModifierKeys(),
           );
-        case 0x43:
+        case 0x43: // C
           return KeyboardEvent(
             logicalKey: LogicalKey.arrowRight,
             modifiers: const ModifierKeys(),
           );
-        case 0x44:
+        case 0x44: // D
           return KeyboardEvent(
             logicalKey: LogicalKey.arrowLeft,
             modifiers: const ModifierKeys(),
           );
-        case 0x48:
+        case 0x48: // H
           return KeyboardEvent(
             logicalKey: LogicalKey.home,
             modifiers: const ModifierKeys(),
           );
-        case 0x46:
+        case 0x46: // F
           return KeyboardEvent(
             logicalKey: LogicalKey.end,
             modifiers: const ModifierKeys(),
           );
-        case 0x5A:
+        case 0x5A: // Z
           return KeyboardEvent(
             logicalKey: LogicalKey.tab,
             modifiers: const ModifierKeys(shift: true),
@@ -323,22 +328,22 @@ class InputParser {
       // Shift+Arrow: ESC [ 1 ; 2 A/B/C/D
       if (sequence.startsWith('\x1B[1;2')) {
         switch (_buffer[5]) {
-          case 0x41:
+          case 0x41: // A
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowUp,
               modifiers: const ModifierKeys(shift: true),
             );
-          case 0x42:
+          case 0x42: // B
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowDown,
               modifiers: const ModifierKeys(shift: true),
             );
-          case 0x43:
+          case 0x43: // C
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowRight,
               modifiers: const ModifierKeys(shift: true),
             );
-          case 0x44:
+          case 0x44: // D
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowLeft,
               modifiers: const ModifierKeys(shift: true),
@@ -349,22 +354,22 @@ class InputParser {
       // Alt+Arrow: ESC [ 1 ; 3 A/B/C/D
       if (sequence.startsWith('\x1B[1;3')) {
         switch (_buffer[5]) {
-          case 0x41:
+          case 0x41: // A
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowUp,
               modifiers: const ModifierKeys(alt: true),
             );
-          case 0x42:
+          case 0x42: // B
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowDown,
               modifiers: const ModifierKeys(alt: true),
             );
-          case 0x43:
+          case 0x43: // C
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowRight,
               modifiers: const ModifierKeys(alt: true),
             );
-          case 0x44:
+          case 0x44: // D
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowLeft,
               modifiers: const ModifierKeys(alt: true),
@@ -375,22 +380,22 @@ class InputParser {
       // Ctrl+Arrow: ESC [ 1 ; 5 A/B/C/D
       if (sequence.startsWith('\x1B[1;5')) {
         switch (_buffer[5]) {
-          case 0x41:
+          case 0x41: // A
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowUp,
               modifiers: const ModifierKeys(ctrl: true),
             );
-          case 0x42:
+          case 0x42: // B
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowDown,
               modifiers: const ModifierKeys(ctrl: true),
             );
-          case 0x43:
+          case 0x43: // C
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowRight,
               modifiers: const ModifierKeys(ctrl: true),
             );
-          case 0x44:
+          case 0x44: // D
             return KeyboardEvent(
               logicalKey: LogicalKey.arrowLeft,
               modifiers: const ModifierKeys(ctrl: true),
@@ -400,7 +405,7 @@ class InputParser {
     }
 
     // Function keys and special keys with ~ terminator
-    if (_buffer.contains(0x7E)) {
+    if (_buffer.contains(0x7E)) { // ~
       final sequence = String.fromCharCodes(_buffer);
 
       // Parse sequences like ESC [ 2 ~ (Insert), ESC [ 3 ~ (Delete), etc.

--- a/lib/src/win32_ansi_stdin.dart
+++ b/lib/src/win32_ansi_stdin.dart
@@ -1,0 +1,430 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:io';
+import 'package:win32/win32.dart' as win32;
+import 'package:ffi/ffi.dart' as ffi;
+
+
+// I have a PR #1009 open on the win32 package to add these missing constants
+
+// Manually define the missing Windows event type constants.
+const int KEY_EVENT = 0x0001;
+const int MOUSE_EVENT = 0x0002;
+
+// For the dwControlKeyState member of the KEY_EVENT_RECORD struct
+const int RIGHT_ALT_PRESSED = 0x0001;
+const int LEFT_ALT_PRESSED = 0x0002;
+const int RIGHT_CTRL_PRESSED = 0x0004;
+const int LEFT_CTRL_PRESSED = 0x0008;
+const int SHIFT_PRESSED = 0x0010;
+
+const int  FROM_LEFT_1ST_BUTTON_PRESSED = 0x0001;
+const int  RIGHTMOST_BUTTON_PRESSED     = 0x0002;
+const int  FROM_LEFT_2ND_BUTTON_PRESSED = 0x0004;
+const int  FROM_LEFT_3RD_BUTTON_PRESSED = 0x0008;
+const int  FROM_LEFT_4TH_BUTTON_PRESSED = 0x0010;
+
+/// A class that emulates a Unix-style Stdin by extending StreamView to behave
+/// like a Stream and implementing the Stdin interface - but specifically sending
+/// the appropriate ANSI escape sequences for mouse and keyboard events on Windows.
+/// As if it were a Unix terminal for which the ANSI commands:
+///    ESC [ ? 1000 h - Send Mouse X & Y on button press and release
+///    ESC [ ? 1002 h - Use Cell Motion Mouse Tracking
+///    ESC [ ? 1003 h - Enable all motion mouse tracking
+///    ESC [ ? 1006 h - Enable SGR mouse mode
+/// had been send to the terminal stdout.
+/// This class is asynchronous and does not support synchronous read methods.
+class Win32AnsiStdin extends StreamView<List<int>> implements Stdin {
+  final StreamController<List<int>> _controller;
+  final _inputHandle = win32.GetStdHandle(win32.STD_INPUT_HANDLE);
+
+  late final int _originalConsoleMode;
+  int _lastButtonState = 0;
+  bool _isListening = false;
+  
+  // Backing fields for required Stdin properties
+  bool _lineMode = false;
+  bool _echoMode = false;
+  bool _echoNewlineMode = false; // New property
+
+  // Factory constructor for proper initialization
+  factory Win32AnsiStdin() {
+    final controller = StreamController<List<int>>();
+    return Win32AnsiStdin._(controller);
+  }
+
+  // Private constructor
+  Win32AnsiStdin._(this._controller) : super(_controller.stream) {
+    final pMode = ffi.calloc<Uint32>();
+    try {
+      win32.GetConsoleMode(_inputHandle, pMode);
+      _originalConsoleMode = pMode.value;
+    } finally {
+      win32.free(pMode);
+    }
+    _startEventLoopIfNeeded();
+  }
+
+  void _startEventLoopIfNeeded() {
+    if (_isListening) return;
+    _isListening = true;
+    
+    final newMode = win32.ENABLE_EXTENDED_FLAGS |
+        (_originalConsoleMode & ~win32.ENABLE_QUICK_EDIT_MODE) |
+        win32.ENABLE_MOUSE_INPUT;
+    win32.SetConsoleMode(_inputHandle, newMode);
+
+    Future(_eventLoop);
+  }
+
+  void close() {
+    if (!_isListening) return;
+    _isListening = false;
+    win32.SetConsoleMode(_inputHandle, _originalConsoleMode);
+    _controller.close();
+    print('\nConsole mode restored.');
+  }
+
+  // --- Overriding the Stdin interface properties ---
+
+  @override
+  bool get hasTerminal => true;
+
+  @override
+  bool get lineMode => _lineMode;
+
+  @override
+  set lineMode(bool mode) => _lineMode = mode;
+
+  @override
+  bool get echoMode => _echoMode;
+
+  @override
+  set echoMode(bool mode) => _echoMode = mode;
+
+  // --- New Required Implementations ---
+  @override
+  bool get echoNewlineMode => _echoNewlineMode;
+
+  @override
+  set echoNewlineMode(bool mode) => _echoNewlineMode = mode;
+
+  @override
+  bool get supportsAnsiEscapes => true;
+  // --- End of New Implementations ---
+
+  @override
+  int readByteSync() {
+    throw UnsupportedError(
+        'Win32Stdin is asynchronous and does not support readByteSync.');
+  }
+
+  @override
+  String? readLineSync(
+      {Encoding encoding = systemEncoding, bool retainNewlines = false}) {
+    throw UnsupportedError(
+        'Win32Stdin is asynchronous and does not support readLineSync.');
+  }
+
+  // --- Event Loop and Translation Logic ---
+
+  Future<void> _eventLoop() async {
+    final pInputRecord = ffi.calloc<win32.INPUT_RECORD>();
+    final pEventsRead = ffi.calloc<Uint32>();
+
+    try {
+      while (_isListening) {
+        if (win32.ReadConsoleInput(_inputHandle, pInputRecord, 1, pEventsRead) != 0) {
+          if (pEventsRead.value > 0) {
+            _translateAndFire(pInputRecord.ref);
+          }
+        }
+        await Future.delayed(Duration.zero);
+      }
+    } finally {
+      win32.free(pInputRecord);
+      win32.free(pEventsRead);
+    }
+  }
+
+  void _addAnsiSequence(String seq) {
+    _controller.add(utf8.encode(seq));
+  }
+
+  void _translateAndFire(win32.INPUT_RECORD event) {
+    if (event.EventType == MOUSE_EVENT) {
+      _translateMouseEvent(event.Event.MouseEvent);
+    } else if (event.EventType == KEY_EVENT) {
+      _translateKeyEvent(event.Event.KeyEvent);
+    }
+  }
+
+  void _translateKeyEventORIG(win32.KEY_EVENT_RECORD keyEvent) {
+    if (keyEvent.bKeyDown == 0) return;
+    final charCode = keyEvent.uChar.UnicodeChar;
+    
+    if (charCode >= 32 && charCode != 127) {
+      _addAnsiSequence(String.fromCharCode(charCode));
+      return;
+    }
+    
+    switch (keyEvent.wVirtualKeyCode) {
+      case win32.VK_UP: _addAnsiSequence('\x1b[A'); break;
+      case win32.VK_DOWN: _addAnsiSequence('\x1b[B'); break;
+      case win32.VK_RIGHT: _addAnsiSequence('\x1b[C'); break;
+      case win32.VK_LEFT: _addAnsiSequence('\x1b[D'); break;
+      case win32.VK_HOME: _addAnsiSequence('\x1b[H'); break;
+      case win32.VK_END: _addAnsiSequence('\x1b[F'); break;
+      case win32.VK_DELETE: _addAnsiSequence('\x1b[3~'); break;
+      case win32.VK_BACK: _addAnsiSequence('\x7f'); break;
+      case win32.VK_RETURN: _addAnsiSequence('\r'); break;
+      case win32.VK_ESCAPE: _addAnsiSequence('\x1b'); break;
+      //case 
+    }
+  }
+
+    /*
+    ANSI CSI (Control Sequence Introducer) for extended keys with modifiers
+    ┌─────────────────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
+    │ Key                     │ Code        │ SHIFT+code  │ CTRL+code   │ ALT+code    │
+    ├─────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+    │ F1                      │ 0;59        │ 0;84        │ 0;94        │ 0;104       │
+    │ F2                      │ 0;60        │ 0;85        │ 0;95        │ 0;105       │
+    │ F3                      │ 0;61        │ 0;86        │ 0;96        │ 0;106       │
+    │ F4                      │ 0;62        │ 0;87        │ 0;97        │ 0;107       │
+    │ F5                      │ 0;63        │ 0;88        │ 0;98        │ 0;108       │
+    │ F6                      │ 0;64        │ 0;89        │ 0;99        │ 0;109       │
+    │ F7                      │ 0;65        │ 0;90        │ 0;100       │ 0;110       │
+    │ F8                      │ 0;66        │ 0;91        │ 0;101       │ 0;111       │
+    │ F9                      │ 0;67        │ 0;92        │ 0;102       │ 0;112       │
+    │ F10                     │ 0;68        │ 0;93        │ 0;103       │ 0;113       │
+    │ F11                     │ 0;133       │ 0;135       │ 0;137       │ 0;139       │
+    │ F12                     │ 0;134       │ 0;136       │ 0;138       │ 0;140       │
+    ├─────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+    │ HOME (num keypad)       │ 0;71        │ 55          │ 0;119       │ --          │
+    │ UP ARROW (num keypad)   │ 0;72        │ 56          │ (0;141)     │ --          │
+    │ PAGE UP (num keypad)    │ 0;73        │ 57          │ 0;132       │ --          │
+    │ LEFT ARROW (num keypad) │ 0;75        │ 52          │ 0;115       │ --          │
+    │ RIGHT ARROW (num keypad)│ 0;77        │ 54          │ 0;116       │ --          │
+    │ END (num keypad)        │ 0;79        │ 49          │ 0;117       │ --          │
+    │ DOWN ARROW (num keypad) │ 0;80        │ 50          │ (0;145)     │ --          │
+    │ PAGE DOWN (num keypad)  │ 0;81        │ 51          │ 0;118       │ --          │
+    │ INSERT (num keypad)     │ 0;82        │ 48          │ (0;146)     │ --          │
+    │ DELETE (num keypad)     │ 0;83        │ 46          │ (0;147)     │ --          │
+    ├─────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+    │ HOME                    │ (224;71)    │ (224;71)    │ (224;119)   │ (224;151)   │
+    │ UP ARROW                │ (224;72)    │ (224;72)    │ (224;141)   │ (224;152)   │
+    │ PAGE UP                 │ (224;73)    │ (224;73)    │ (224;132)   │ (224;153)   │
+    │ LEFT ARROW              │ (224;75)    │ (224;75)    │ (224;115)   │ (224;155)   │
+    │ RIGHT ARROW             │ (224;77)    │ (224;77)    │ (224;116)   │ (224;157)   │
+    │ END                     │ (224;79)    │ (224;79)    │ (224;117)   │ (224;159)   │
+    │ DOWN ARROW              │ (224;80)    │ (224;80)    │ (224;145)   │ (224;154)   │
+    │ PAGE DOWN               │ (224;81)    │ (224;81)    │ (224;118)   │ (224;161)   │
+    │ INSERT                  │ (224;82)    │ (224;82)    │ (224;146)   │ (224;162)   │
+    │ DELETE                  │ (224;83)    │ (224;83)    │ (224;147)   │ (224;163)   │
+    ├─────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+    │ PRINT SCREEN            │ --          │ --          │ 0;114       │ --          │
+    │ PAUSE/BREAK             │ --          │ --          │ 0;0         │ --          │
+    │ BACKSPACE               │ 8           │ 8           │ 127         │ (0)         │
+    │ ENTER                   │ 13          │ --          │ 10          │ (0)         │
+    │ TAB                     │ 9           │ 0;15        │ (0;148)     │ (0;165)     │
+    │ NULL                    │ 0;3         │ --          │ --          │ --          │
+    ├─────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+    │ A                       │ 97          │ 65          │ 1           │ 0;30        │
+    │ B                       │ 98          │ 66          │ 2           │ 0;48        │
+    │ C                       │ 99          │ 67          │ 3           │ 0;46        │
+    │ D                       │ 100         │ 68          │ 4           │ 0;32        │
+    │ E                       │ 101         │ 69          │ 5           │ 0;18        │
+    │ F                       │ 102         │ 70          │ 6           │ 0;33        │
+    │ G                       │ 103         │ 71          │ 7           │ 0;34        │
+    │ H                       │ 104         │ 72          │ 8           │ 0;35        │
+    │ I                       │ 105         │ 73          │ 9           │ 0;23        │
+    │ J                       │ 106         │ 74          │ 10          │ 0;36        │
+    │ K                       │ 107         │ 75          │ 11          │ 0;37        │
+    │ L                       │ 108         │ 76          │ 12          │ 0;38        │
+    │ M                       │ 109         │ 77          │ 13          │ 0;50        │
+    │ N                       │ 110         │ 78          │ 14          │ 0;49        │
+    │ O                       │ 111         │ 79          │ 15          │ 0;24        │
+    │ P                       │ 112         │ 80          │ 16          │ 0;25        │
+    │ Q                       │ 113         │ 81          │ 17          │ 0;16        │
+    │ R                       │ 114         │ 82          │ 18          │ 0;19        │
+    │ S                       │ 115         │ 83          │ 19          │ 0;31        │
+    │ T                       │ 116         │ 84          │ 20          │ 0;20        │
+    │ U                       │ 117         │ 85          │ 21          │ 0;22        │
+    │ V                       │ 118         │ 86          │ 22          │ 0;47        │
+    │ W                       │ 119         │ 87          │ 23          │ 0;17        │
+    │ X                       │ 120         │ 88          │ 24          │ 0;45        │
+    │ Y                       │ 121         │ 89          │ 25          │ 0;21        │
+    │ Z                       │ 122         │ 90          │ 26          │ 0;44        │
+    ├─────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+    │ 1                       │ 49          │ 33          │ --          │ 0;120       │
+    │ 2                       │ 50          │ 64          │ 0           │ 0;121       │
+    │ 3                       │ 51          │ 35          │ --          │ 0;122       │
+    │ 4                       │ 52          │ 36          │ --          │ 0;123       │
+    │ 5                       │ 53          │ 37          │ --          │ 0;124       │
+    │ 6                       │ 54          │ 94          │ 30          │ 0;125       │
+    │ 7                       │ 55          │ 38          │ --          │ 0;126       │
+    │ 8                       │ 56          │ 42          │ --          │ 0;127       │
+    │ 9                       │ 57          │ 40          │ --          │ 0;128       │
+    │ 0                       │ 48          │ 41          │ --          │ 0;129       │
+    │ -                       │ 45          │ 95          │ 31          │ 0;130       │
+    │ =                       │ 61          │ 43          │ --          │ 0;131       │
+    │ [                       │ 91          │ 123         │ 27          │ 0;26        │
+    │ ]                       │ 93          │ 125         │ 29          │ 0;27        │
+    │ \                       │ 92          │ 124         │ 28          │ 0;43        │
+    │ ;                       │ 59          │ 58          │ --          │ 0;39        │
+    │ '                       │ 39          │ 34          │ --          │ 0;40        │
+    │ ,                       │ 44          │ 60          │ --          │ 0;51        │
+    │ .                       │ 46          │ 62          │ --          │ 0;52        │
+    │ /                       │ 47          │ 63          │ --          │ 0;53        │
+    │ `                       │ 96          │ 126         │ --          │ (0;41)      │
+    ├─────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+    │ ENTER (keypad)          │ 13          │ --          │ 10          │ (0;166)     │
+    │ / (keypad)              │ 47          │ 47          │ (0;142)     │ (0;74)      │
+    │ * (keypad)              │ 42          │ (0;144)     │ (0;78)      │ --          │
+    │ - (keypad)              │ 45          │ 45          │ (0;149)     │ (0;164)     │
+    │ + (keypad)              │ 43          │ 43          │ (0;150)     │ (0;55)      │
+    │ 5 (keypad)              │ (0;76)      │ 53          │ (0;143)     │ --          │
+    └─────────────────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
+    */
+
+ /// Calculates the ANSI modifier value based on the key state.
+  /// ANSI modifiers are 1-based: 1=None, 2=Shift, 3=Alt, 5=Ctrl, etc.
+  int _getAnsiModifier(int controlKeyState) {
+    int modifier = 1; // Base value for no modifier
+    if ((controlKeyState & SHIFT_PRESSED) != 0) {
+      modifier += 1;
+    }
+    if ((controlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)) != 0) {
+      modifier += 2;
+    }
+    if ((controlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) != 0) {
+      modifier += 4;
+    }
+    return modifier;
+  }
+  
+  void _translateKeyEvent(win32.KEY_EVENT_RECORD keyEvent) {
+    if (keyEvent.bKeyDown == 0) return;
+
+    final controlKeyState = keyEvent.dwControlKeyState;
+    final virtualKeyCode = keyEvent.wVirtualKeyCode;
+    
+    // Handle standard Ctrl+[A-Z] combinations which map to ASCII 1-26
+    final isCtrl = (controlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) != 0;
+    final isAlt = (controlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)) != 0;
+    
+    if (isCtrl && !isAlt && virtualKeyCode >= 'A'.codeUnitAt(0) && virtualKeyCode <= 'Z'.codeUnitAt(0)) {
+      final charCode = virtualKeyCode - 'A'.codeUnitAt(0) + 1;
+      _addAnsiSequence(String.fromCharCode(charCode));
+      return;
+    }
+
+    final modifier = _getAnsiModifier(controlKeyState);
+
+    // Map of Virtual Key Codes to their ANSI escape character codes.
+    // This handles keys that use the '~' suffix format.
+    const keyMap = {
+      win32.VK_INSERT: 2, win32.VK_DELETE: 3,
+      win32.VK_HOME: 1,   win32.VK_END: 4,
+      win32.VK_PRIOR: 5,  win32.VK_NEXT: 6, // Page Up, Page Down
+      win32.VK_F1: 11,    win32.VK_F2: 12,
+      win32.VK_F3: 13,    win32.VK_F4: 14,
+      win32.VK_F5: 15,    win32.VK_F6: 17,
+      win32.VK_F7: 18,    win32.VK_F8: 19,
+      win32.VK_F9: 20,    win32.VK_F10: 21,
+      win32.VK_F11: 23,   win32.VK_F12: 24,
+    };
+
+    if (keyMap.containsKey(virtualKeyCode)) {
+      final code = keyMap[virtualKeyCode]!;
+      // Modified keys use the format: ESC [ <keycode> ; <modifier> ~
+      if (modifier > 1) {
+        _addAnsiSequence('\x1b[${code};${modifier}~');
+      } else {
+        _addAnsiSequence('\x1b[${code}~');
+      }
+      return;
+    }
+    
+    // Handles keys that use a letter suffix (e.g., arrows)
+    const letterSuffixMap = {
+      win32.VK_UP: 'A', win32.VK_DOWN: 'B',
+      win32.VK_RIGHT: 'C', win32.VK_LEFT: 'D',
+    };
+
+    if (letterSuffixMap.containsKey(virtualKeyCode)) {
+      final char = letterSuffixMap[virtualKeyCode]!;
+      // Modified arrows use the format: ESC [ 1 ; <modifier> <char>
+      if (modifier > 1) {
+        _addAnsiSequence('\x1b[1;${modifier}$char');
+      } else {
+        _addAnsiSequence('\x1b[$char');
+      }
+      return;
+    }
+
+    // Fallback for printable characters and other simple keys
+    final charCode = keyEvent.uChar.UnicodeChar;
+    if (charCode != 0 && !isCtrl && !isAlt) {
+       _addAnsiSequence(String.fromCharCode(charCode));
+       return;
+    }
+    
+    // Handle special cases that don't produce a printable character
+    switch (virtualKeyCode) {
+        case win32.VK_RETURN: _addAnsiSequence('\r'); break;
+        case win32.VK_ESCAPE: _addAnsiSequence('\x1b'); break;
+        case win32.VK_BACK: _addAnsiSequence('\x7f'); break; // Backspace
+        case win32.VK_TAB: _addAnsiSequence('\t'); break;
+    }
+  }
+
+
+  void _translateMouseEvent(win32.MOUSE_EVENT_RECORD mouseEvent) {
+    final pos = mouseEvent.dwMousePosition;
+    final flags = mouseEvent.dwEventFlags;
+    final buttonState = mouseEvent.dwButtonState;
+
+    final col = pos.X + 1;
+    final row = pos.Y + 1;
+
+    if (flags & win32.MOUSEEVENTF_WHEEL != 0) {
+      final isUp = (buttonState >> 16) > 0;
+      final button = isUp ? 64 : 65;
+      _addAnsiSequence('\x1b[<${button};${col};${row}M');
+      return;
+    }
+
+    if (flags & win32.MOUSEEVENTF_MOVE != 0) {
+      if (buttonState != 0) {
+        final button = 32 + _getButtonCode(buttonState);
+        _addAnsiSequence('\x1b[<${button};${col};${row}M');
+      } else {
+        _addAnsiSequence('\x1b[<35;${col};${row}m');
+      }
+    } else {
+      final releasedButton = _lastButtonState & ~buttonState;
+      if (releasedButton != 0) {
+        final button = _getButtonCode(releasedButton);
+        _addAnsiSequence('\x1b[<${button};${col};${row}m');
+      }
+
+      final pressedButton = buttonState & ~_lastButtonState;
+      if (pressedButton != 0) {
+        final button = _getButtonCode(pressedButton);
+        _addAnsiSequence('\x1b[<${button};${col};${row}M');
+      }
+    }
+
+    _lastButtonState = buttonState;
+  }
+  
+  int _getButtonCode(int buttonState) {
+    if ((buttonState & FROM_LEFT_1ST_BUTTON_PRESSED) != 0) return 0;
+    if ((buttonState & RIGHTMOST_BUTTON_PRESSED) != 0) return 2;
+    if ((buttonState & FROM_LEFT_2ND_BUTTON_PRESSED) != 0) return 1;
+    return 0;
+  }
+}

--- a/lib/src/win32_ansi_stdin.dart
+++ b/lib/src/win32_ansi_stdin.dart
@@ -46,7 +46,7 @@ class Win32AnsiStdin extends StreamView<List<int>> implements Stdin {
   // Backing fields for required Stdin properties
   bool _lineMode = false;
   bool _echoMode = false;
-  bool _echoNewlineMode = false; // New property
+  bool _echoNewlineMode = false;
 
   // Factory constructor for proper initialization
   factory Win32AnsiStdin() {
@@ -87,7 +87,6 @@ class Win32AnsiStdin extends StreamView<List<int>> implements Stdin {
   }
 
   // --- Overriding the Stdin interface properties ---
-
   @override
   bool get hasTerminal => true;
 
@@ -103,7 +102,6 @@ class Win32AnsiStdin extends StreamView<List<int>> implements Stdin {
   @override
   set echoMode(bool mode) => _echoMode = mode;
 
-  // --- New Required Implementations ---
   @override
   bool get echoNewlineMode => _echoNewlineMode;
 
@@ -112,7 +110,6 @@ class Win32AnsiStdin extends StreamView<List<int>> implements Stdin {
 
   @override
   bool get supportsAnsiEscapes => true;
-  // --- End of New Implementations ---
 
   @override
   int readByteSync() {
@@ -160,31 +157,7 @@ class Win32AnsiStdin extends StreamView<List<int>> implements Stdin {
     }
   }
 
-  void _translateKeyEventORIG(win32.KEY_EVENT_RECORD keyEvent) {
-    if (keyEvent.bKeyDown == 0) return;
-    final charCode = keyEvent.uChar.UnicodeChar;
-    
-    if (charCode >= 32 && charCode != 127) {
-      _addAnsiSequence(String.fromCharCode(charCode));
-      return;
-    }
-    
-    switch (keyEvent.wVirtualKeyCode) {
-      case win32.VK_UP: _addAnsiSequence('\x1b[A'); break;
-      case win32.VK_DOWN: _addAnsiSequence('\x1b[B'); break;
-      case win32.VK_RIGHT: _addAnsiSequence('\x1b[C'); break;
-      case win32.VK_LEFT: _addAnsiSequence('\x1b[D'); break;
-      case win32.VK_HOME: _addAnsiSequence('\x1b[H'); break;
-      case win32.VK_END: _addAnsiSequence('\x1b[F'); break;
-      case win32.VK_DELETE: _addAnsiSequence('\x1b[3~'); break;
-      case win32.VK_BACK: _addAnsiSequence('\x7f'); break;
-      case win32.VK_RETURN: _addAnsiSequence('\r'); break;
-      case win32.VK_ESCAPE: _addAnsiSequence('\x1b'); break;
-      //case 
-    }
-  }
-
-    /*
+  /*
     ANSI CSI (Control Sequence Introducer) for extended keys with modifiers
     ┌─────────────────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
     │ Key                     │ Code        │ SHIFT+code  │ CTRL+code   │ ALT+code    │
@@ -289,7 +262,7 @@ class Win32AnsiStdin extends StreamView<List<int>> implements Stdin {
     └─────────────────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
     */
 
- /// Calculates the ANSI modifier value based on the key state.
+  /// Calculates the ANSI modifier value based on the key state.
   /// ANSI modifiers are 1-based: 1=None, 2=Shift, 3=Alt, 5=Ctrl, etc.
   int _getAnsiModifier(int controlKeyState) {
     int modifier = 1; // Base value for no modifier

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nocterm
 description: A Flutter-like framework for terminal UIs.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/norbert515/nocterm
 homepage: https://nocterm.dev
 
@@ -21,6 +21,8 @@ dependencies:
   quiver: ^3.0.0
   equatable: ^2.0.3
   zmodem: ^0.0.6
+  win32: ^5.14.0
+  ffi: ^2.1.4
 
 dev_dependencies:
   test: ^1.25.6


### PR DESCRIPTION
This PR provides a wrapper around `stdin`  on the Windows platform so that it provides standard ANSI CSI sequences for mouse and keyboard events.

As if it were a Unix terminal `stdin` for which these ANSI commands had been sent to the terminal's `stdout`:
    ESC [ ? 1000 h - Send Mouse X & Y on button press and release
    ESC [ ? 1002 h - Use Cell Motion Mouse Tracking
    ESC [ ? 1003 h - Enable all motion mouse tracking
    ESC [ ? 1006 h - Enable SGR mouse mode
