### PR TITLE
Add differential rendering optimization

### DIFF
--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -15,6 +15,18 @@ class Cell {
       style: style ?? this.style,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is Cell &&
+        other.char == char &&
+        other.style == style;
+  }
+
+  @override
+  int get hashCode => Object.hash(char, style);
 }
 
 class Buffer {


### PR DESCRIPTION
Implement partial rendering that only updates cells that changed since the previous frame, significantly reducing terminal output for mostly static UIs.

- Add Cell equality comparison (char + style)
- Track previous frame buffer for comparison
- Skip unchanged cells during render
- Force full redraw on terminal resize