### PR TITLE
research: mouse cursor control investigation

### DIFF
--- a/docs/mouse_cursor_research.md
+++ b/docs/mouse_cursor_research.md
@@ -1,0 +1,185 @@
+# Mouse Cursor Control Research
+
+## Overview
+
+This document summarizes research into controlling the mouse pointer cursor from a terminal TUI application, with the goal of providing visual feedback (e.g., I-beam for text, pointer for buttons) during user interaction.
+
+## The Challenge
+
+Terminal applications run as child processes of the terminal emulator. The **terminal owns the window** and therefore controls the mouse cursor. Our TUI app can only communicate via stdin/stdout escape sequences.
+
+```
+┌─────────────────────────────────┐
+│  Terminal (Warp/Kitty/iTerm)    │  ← Window owner, controls cursor
+│  ┌───────────────────────────┐  │
+│  │  TUI app (child process)   │  │  ← Cannot directly control cursor
+│  │  └── stdin/stdout ────────│──│──── Only communication channel
+│  └───────────────────────────┘  │
+└─────────────────────────────────┘
+```
+
+---
+
+## Approach 1: OSC 22 Escape Sequence (Recommended)
+
+**Format:** `ESC ] 22 ; <shape> ESC \`
+
+### Supported Shapes (CSS cursor names)
+- `default` - Normal arrow
+- `pointer` - Hand/link cursor
+- `text` - I-beam for text selection
+- `crosshair` - Precision selection
+- `grab` / `grabbing` - Draggable items
+- `move` - Moving something
+- `not-allowed` - Disabled
+- `wait` - Loading
+- `cell`, `copy`, `help`, `zoom-in`, `zoom-out`, resize cursors, etc.
+
+### Terminal Support
+
+| Terminal | OSC 22 Support |
+|----------|----------------|
+| ✅ Kitty | Full support (30 CSS cursor names) |
+| ✅ foot | Supported |
+| ✅ xterm | Supported (original proposal) |
+| ✅ Alacritty | Supported (enable with `terminal.osc22`) |
+| ✅ WezTerm | Supported |
+| ❌ **Warp** | Not supported |
+| ❌ macOS Terminal.app | Not supported |
+| ❓ iTerm2 | Unknown |
+
+### Implementation
+
+```dart
+// Set cursor to pointer (hand)
+stdout.write('\x1b]22;pointer\x1b\\');
+
+// Set cursor to I-beam (text)
+stdout.write('\x1b]22;text\x1b\\');
+
+// Reset to default
+stdout.write('\x1b]22;default\x1b\\');
+```
+
+### Demo
+See `example/mouse_pointer_demo.dart`
+
+---
+
+## Approach 2: CGS Private APIs (macOS only, hacky)
+
+Uses undocumented CoreGraphics Services APIs to control the cursor system-wide.
+
+### Key Functions
+
+```c
+// Get connection to WindowServer
+CGSConnectionID CGSMainConnectionID(void);
+
+// Enable background cursor control (the magic trick!)
+CGSSetConnectionProperty(cid, cid, CFSTR("SetsCursorInBackground"), kCFBooleanTrue);
+
+// Set cursor type
+CGSSetSystemDefinedCursor(cid, cursorId);
+
+// Show/hide cursor
+CGSShowCursor(cid);
+CGSHideCursor(cid);
+```
+
+### Cursor IDs
+
+| ID | Cursor |
+|----|--------|
+| 0 | Arrow |
+| 1 | I-Beam |
+| 5 | Move |
+| 7 | Wait/Busy |
+| 10 | Pointing Hand |
+| 11 | Open Hand |
+| 12 | Closed Hand |
+
+### Pros
+- Works in **any terminal** including Warp
+- System-wide cursor control
+
+### Cons
+- **Private APIs** - will get rejected from Mac App Store
+- May break in future macOS versions
+- Cursor resets when switching tabs/windows (requires focus tracking to reapply)
+- Only works on macOS
+
+### Focus Tracking
+
+To handle cursor reset on tab switch, use xterm focus reporting:
+
+```dart
+// Enable focus reporting
+stdout.write('\x1b[?1004h');
+
+// Terminal sends:
+// ESC [ I  - when focus gained
+// ESC [ O  - when focus lost
+
+// On focus gained, reapply cursor
+```
+
+### Demos
+- `example/cgs_cursor_demo.dart` - Basic CGS cursor control
+- `example/cgs_cursor_focus_demo.dart` - With focus tracking
+
+---
+
+## Approach 3: Text Cursor Shape (DECSCUSR)
+
+This controls the **text cursor** (blinking block/bar/underline), not the mouse pointer.
+
+**Format:** `ESC [ N SP q` (where SP is a literal space)
+
+| Value | Cursor Style |
+|-------|-------------|
+| 0, 1 | Blinking block |
+| 2 | Steady block |
+| 3 | Blinking underline |
+| 4 | Steady underline |
+| 5 | Blinking bar (I-beam) |
+| 6 | Steady bar (I-beam) |
+
+Widely supported in all terminals. Used by Vim for mode indication.
+
+### Demo
+See `example/cursor_shape_demo.dart`
+
+---
+
+## Recommendation
+
+### For Maximum Compatibility
+1. Use **OSC 22** where supported (detect via query: `ESC ] 22 ; ?pointer ESC \`)
+2. **Gracefully degrade** in unsupported terminals (no cursor changes)
+3. Consider the CGS approach only for macOS-specific builds distributed outside App Store
+
+### For Warp Specifically
+- File a feature request for OSC 22 support at github.com/warpdotdev/Warp
+- The CGS private API approach works but requires focus tracking
+
+---
+
+## Files Created
+
+| File | Description |
+|------|-------------|
+| `example/cursor_shape_demo.dart` | Text cursor shape (DECSCUSR) |
+| `example/mouse_pointer_demo.dart` | OSC 22 mouse pointer (Kitty) |
+| `example/cgs_cursor_demo.dart` | CGS private APIs (macOS) |
+| `example/cgs_cursor_focus_demo.dart` | CGS with focus tracking |
+
+---
+
+## References
+
+- [Kitty Pointer Shapes](https://sw.kovidgoyal.net/kitty/pointer-shapes/)
+- [VT510 DECSCUSR](https://vt100.net/docs/vt510-rm/DECSCUSR.html)
+- [CGSInternal Headers](https://github.com/NUIKit/CGSInternal)
+- [Mousecape (CGS cursor manager)](https://github.com/alexzielenski/Mousecape)
+- [XTerm Control Sequences](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html)

--- a/example/cgs_cursor_demo.dart
+++ b/example/cgs_cursor_demo.dart
@@ -1,0 +1,308 @@
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/ffi.dart';
+
+/// Proof-of-concept: System-wide cursor control using CGS private APIs
+///
+/// This uses undocumented CoreGraphics Services APIs to control the cursor
+/// system-wide, bypassing the normal NSCursor frontmost-app restriction.
+///
+/// The key trick is using CGSSetConnectionProperty to set "SetsCursorInBackground"
+/// which tells WindowServer we're allowed to control the cursor from background.
+///
+/// WARNING: These are PRIVATE APIs that:
+/// - Will get your app rejected from the Mac App Store
+/// - May break in future macOS versions
+/// - Work without SIP disabled (for basic operations)
+///
+/// Run with: dart run example/cgs_cursor_demo.dart
+
+// CGS types
+typedef CGSConnectionID = Int32;
+typedef CGError = Int32;
+typedef CGSCursorID = Int32;
+
+// CGSMainConnectionID() -> CGSConnectionID
+typedef CGSMainConnectionIDNative = Int32 Function();
+typedef CGSMainConnectionIDDart = int Function();
+
+// CGSShowCursor(CGSConnectionID) -> CGError
+typedef CGSShowCursorNative = Int32 Function(Int32 cid);
+typedef CGSShowCursorDart = int Function(int cid);
+
+// CGSHideCursor(CGSConnectionID) -> CGError
+typedef CGSHideCursorNative = Int32 Function(Int32 cid);
+typedef CGSHideCursorDart = int Function(int cid);
+
+// CGSObscureCursor(CGSConnectionID) -> CGError (hide until mouse moves)
+typedef CGSObscureCursorNative = Int32 Function(Int32 cid);
+typedef CGSObscureCursorDart = int Function(int cid);
+
+// CGSSetSystemDefinedCursor(CGSConnectionID, CGSCursorID) -> CGError
+typedef CGSSetSystemDefinedCursorNative = Int32 Function(
+    Int32 cid, Int32 cursor);
+typedef CGSSetSystemDefinedCursorDart = int Function(int cid, int cursor);
+
+// CGSSetConnectionProperty(CGSConnectionID, CGSConnectionID, CFStringRef key, CFTypeRef value) -> CGError
+typedef CGSSetConnectionPropertyNative = Int32 Function(
+    Int32 cid, Int32 targetCid, Pointer key, Pointer value);
+typedef CGSSetConnectionPropertyDart = int Function(
+    int cid, int targetCid, Pointer key, Pointer value);
+
+// CFStringCreateWithCString
+typedef CFStringCreateWithCStringNative = Pointer Function(
+    Pointer alloc, Pointer<Utf8> cStr, Uint32 encoding);
+typedef CFStringCreateWithCStringDart = Pointer Function(
+    Pointer alloc, Pointer<Utf8> cStr, int encoding);
+
+// CFBooleanGetValue / kCFBooleanTrue
+typedef CFBooleanGetTypeIDNative = Uint64 Function();
+typedef CFBooleanGetTypeIDDart = int Function();
+
+// System cursor IDs (from CGSInternal)
+class CGSCursor {
+  static const int arrow = 0; // Standard arrow
+  static const int iBeam = 1; // Text I-beam
+  static const int iBeamXOR = 2; // I-beam XOR variant
+  static const int alias = 3; // Alias arrow
+  static const int copy = 4; // Copy arrow
+  static const int move = 5; // Move cursor
+  static const int arrowContext = 6; // Contextual menu arrow
+  static const int wait = 7; // Wait/busy cursor
+  static const int empty = 8; // Empty/hidden cursor
+  // More cursors (9-44) include resize cursors, hands, zoom, etc.
+  static const int pointingHand = 10; // Pointing hand (link cursor)
+  static const int openHand = 11; // Open hand (grab)
+  static const int closedHand = 12; // Closed hand (grabbing)
+  static const int crosshair = 13; // Crosshair
+}
+
+void main() async {
+  print('CGS Private API Cursor Demo (with SetsCursorInBackground)');
+  print('==========================================================\n');
+
+  if (!Platform.isMacOS) {
+    print('This demo only works on macOS');
+    return;
+  }
+
+  try {
+    // Load frameworks
+    final coreGraphics = DynamicLibrary.open(
+        '/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics');
+    final coreFoundation = DynamicLibrary.open(
+        '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation');
+
+    print('Loaded CoreGraphics and CoreFoundation frameworks');
+
+    // Look up CGSMainConnectionID
+    late CGSMainConnectionIDDart cgsMainConnectionID;
+    try {
+      cgsMainConnectionID = coreGraphics.lookupFunction<
+          CGSMainConnectionIDNative,
+          CGSMainConnectionIDDart>('CGSMainConnectionID');
+      print('Found CGSMainConnectionID');
+    } catch (e) {
+      print('CGSMainConnectionID not found - trying _CGSDefaultConnection');
+      cgsMainConnectionID = coreGraphics.lookupFunction<
+          CGSMainConnectionIDNative,
+          CGSMainConnectionIDDart>('_CGSDefaultConnection');
+    }
+
+    // Get connection ID
+    final connectionId = cgsMainConnectionID();
+    print('Got CGS connection ID: $connectionId');
+
+    if (connectionId == 0) {
+      print('WARNING: Connection ID is 0 - this may indicate a problem');
+      return;
+    }
+
+    // Look up CGSSetConnectionProperty - THE KEY TO BACKGROUND CURSOR CONTROL
+    CGSSetConnectionPropertyDart? cgsSetConnectionProperty;
+    try {
+      cgsSetConnectionProperty = coreGraphics.lookupFunction<
+          CGSSetConnectionPropertyNative,
+          CGSSetConnectionPropertyDart>('CGSSetConnectionProperty');
+      print('Found CGSSetConnectionProperty');
+    } catch (e) {
+      print('CGSSetConnectionProperty not found: $e');
+    }
+
+    // Look up CFStringCreateWithCString
+    final cfStringCreate = coreFoundation.lookupFunction<
+        CFStringCreateWithCStringNative,
+        CFStringCreateWithCStringDart>('CFStringCreateWithCString');
+
+    // Get kCFBooleanTrue
+    final kCFBooleanTruePtr = coreFoundation.lookup<Pointer>('kCFBooleanTrue');
+    final kCFBooleanTrue = kCFBooleanTruePtr.value;
+    print('Got kCFBooleanTrue: $kCFBooleanTrue');
+
+    // Set "SetsCursorInBackground" property - this is the magic!
+    if (cgsSetConnectionProperty != null) {
+      print('\n*** Setting SetsCursorInBackground property ***');
+
+      // Create CFString for the property key
+      final keyStr = 'SetsCursorInBackground'.toNativeUtf8();
+      final cfKey =
+          cfStringCreate(nullptr, keyStr, 0x08000100); // kCFStringEncodingUTF8
+
+      if (cfKey != nullptr) {
+        final result = cgsSetConnectionProperty(
+            connectionId, connectionId, cfKey, kCFBooleanTrue);
+        print('CGSSetConnectionProperty returned: $result (0 = success)');
+
+        if (result == 0) {
+          print(
+              'SUCCESS! We should now be able to set cursors from background!\n');
+        }
+      } else {
+        print('Failed to create CFString for key');
+      }
+    }
+
+    // Look up cursor functions
+    CGSShowCursorDart? cgsShowCursor;
+    CGSHideCursorDart? cgsHideCursor;
+    CGSObscureCursorDart? cgsObscureCursor;
+    CGSSetSystemDefinedCursorDart? cgsSetSystemDefinedCursor;
+
+    try {
+      cgsShowCursor =
+          coreGraphics.lookupFunction<CGSShowCursorNative, CGSShowCursorDart>(
+              'CGSShowCursor');
+      print('Found CGSShowCursor');
+    } catch (e) {
+      print('CGSShowCursor not found: $e');
+    }
+
+    try {
+      cgsHideCursor =
+          coreGraphics.lookupFunction<CGSHideCursorNative, CGSHideCursorDart>(
+              'CGSHideCursor');
+      print('Found CGSHideCursor');
+    } catch (e) {
+      print('CGSHideCursor not found: $e');
+    }
+
+    try {
+      cgsObscureCursor = coreGraphics.lookupFunction<CGSObscureCursorNative,
+          CGSObscureCursorDart>('CGSObscureCursor');
+      print('Found CGSObscureCursor');
+    } catch (e) {
+      print('CGSObscureCursor not found: $e');
+    }
+
+    try {
+      cgsSetSystemDefinedCursor = coreGraphics.lookupFunction<
+          CGSSetSystemDefinedCursorNative,
+          CGSSetSystemDefinedCursorDart>('CGSSetSystemDefinedCursor');
+      print('Found CGSSetSystemDefinedCursor');
+    } catch (e) {
+      print('CGSSetSystemDefinedCursor not found: $e');
+    }
+
+    print('\n--- Tests (with SetsCursorInBackground enabled) ---\n');
+
+    // Test 1: Hide/Show cursor
+    if (cgsHideCursor != null && cgsShowCursor != null) {
+      print('Test 1: Hiding cursor for 2 seconds...');
+      final hideResult = cgsHideCursor(connectionId);
+      print('  CGSHideCursor returned: $hideResult');
+
+      await Future.delayed(Duration(seconds: 2));
+
+      final showResult = cgsShowCursor(connectionId);
+      print('  CGSShowCursor returned: $showResult');
+      print('  Did the cursor disappear?\n');
+    }
+
+    // Test 2: Change cursor type
+    if (cgsSetSystemDefinedCursor != null) {
+      print('Test 2: Changing cursor types...');
+      print('  (Watch the cursor change as you hover over terminal!)\n');
+
+      final cursors = [
+        (CGSCursor.arrow, 'Arrow'),
+        (CGSCursor.iBeam, 'I-Beam'),
+        (CGSCursor.crosshair, 'Crosshair'),
+        (CGSCursor.pointingHand, 'Pointing Hand'),
+        (CGSCursor.openHand, 'Open Hand'),
+        (CGSCursor.wait, 'Wait/Busy'),
+        (CGSCursor.move, 'Move'),
+        (CGSCursor.arrow, 'Arrow (reset)'),
+      ];
+
+      for (final (cursorId, name) in cursors) {
+        print('  Setting cursor to: $name (ID: $cursorId)');
+        final result = cgsSetSystemDefinedCursor(connectionId, cursorId);
+        print('    Result: $result');
+        await Future.delayed(Duration(milliseconds: 2000));
+      }
+    }
+
+    print('\n--- Interactive Mode ---');
+    print('Press keys to change cursor:');
+    print('  a = arrow        t = I-beam (text)');
+    print('  c = crosshair    p = pointing hand');
+    print('  g = open hand    m = move');
+    print('  w = wait/busy    x = closed hand');
+    print('  h = HIDE cursor  s = SHOW cursor');
+    print('  q = quit\n');
+
+    stdin.echoMode = false;
+    stdin.lineMode = false;
+
+    await for (final input in stdin) {
+      final char = String.fromCharCode(input.first);
+
+      if (char == 'q') break;
+
+      switch (char) {
+        case 'a':
+          cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.arrow);
+          print('Set to arrow');
+        case 't':
+          cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.iBeam);
+          print('Set to I-beam');
+        case 'c':
+          cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.crosshair);
+          print('Set to crosshair');
+        case 'p':
+          cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.pointingHand);
+          print('Set to pointing hand');
+        case 'g':
+          cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.openHand);
+          print('Set to open hand');
+        case 'x':
+          cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.closedHand);
+          print('Set to closed hand');
+        case 'm':
+          cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.move);
+          print('Set to move');
+        case 'w':
+          cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.wait);
+          print('Set to wait');
+        case 'h':
+          cgsHideCursor?.call(connectionId);
+          print('HIDDEN - move mouse to another window and back');
+        case 's':
+          cgsShowCursor?.call(connectionId);
+          print('SHOWN');
+      }
+    }
+
+    // Reset cursor
+    cgsSetSystemDefinedCursor?.call(connectionId, CGSCursor.arrow);
+    cgsShowCursor?.call(connectionId);
+
+    stdin.echoMode = true;
+    stdin.lineMode = true;
+  } catch (e, stack) {
+    print('Error: $e');
+    print(stack);
+  }
+
+  print('\nDone! Cursor should be reset to normal.');
+}

--- a/example/cgs_cursor_focus_demo.dart
+++ b/example/cgs_cursor_focus_demo.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/ffi.dart';
+
+/// Enhanced cursor demo with focus tracking
+///
+/// Uses xterm focus reporting (CSI ? 1004 h) to detect when terminal
+/// gains/loses focus, and reapplies cursor when focus is regained.
+///
+/// Run with: dart run example/cgs_cursor_focus_demo.dart
+
+// CGS types and functions (same as before)
+typedef CGSConnectionID = Int32;
+typedef CGSMainConnectionIDNative = Int32 Function();
+typedef CGSMainConnectionIDDart = int Function();
+typedef CGSSetSystemDefinedCursorNative = Int32 Function(
+    Int32 cid, Int32 cursor);
+typedef CGSSetSystemDefinedCursorDart = int Function(int cid, int cursor);
+typedef CGSSetConnectionPropertyNative = Int32 Function(
+    Int32 cid, Int32 targetCid, Pointer key, Pointer value);
+typedef CGSSetConnectionPropertyDart = int Function(
+    int cid, int targetCid, Pointer key, Pointer value);
+typedef CFStringCreateWithCStringNative = Pointer Function(
+    Pointer alloc, Pointer<Utf8> cStr, Uint32 encoding);
+typedef CFStringCreateWithCStringDart = Pointer Function(
+    Pointer alloc, Pointer<Utf8> cStr, int encoding);
+
+class CGSCursor {
+  static const int arrow = 0;
+  static const int iBeam = 1;
+  static const int crosshair = 5; // Note: IDs may vary
+  static const int pointingHand = 10;
+  static const int wait = 7;
+}
+
+// Current cursor state
+int _currentCursorId = CGSCursor.arrow;
+int _connectionId = 0;
+CGSSetSystemDefinedCursorDart? _setCursor;
+
+void main() async {
+  print('CGS Cursor with Focus Tracking Demo');
+  print('====================================\n');
+
+  if (!Platform.isMacOS) {
+    print('This demo only works on macOS');
+    return;
+  }
+
+  try {
+    // Initialize CGS
+    final coreGraphics = DynamicLibrary.open(
+        '/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics');
+    final coreFoundation = DynamicLibrary.open(
+        '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation');
+
+    final cgsMainConnectionID = coreGraphics.lookupFunction<
+        CGSMainConnectionIDNative,
+        CGSMainConnectionIDDart>('CGSMainConnectionID');
+
+    _connectionId = cgsMainConnectionID();
+    print('CGS connection ID: $_connectionId');
+
+    // Set up SetsCursorInBackground
+    final cgsSetConnectionProperty = coreGraphics.lookupFunction<
+        CGSSetConnectionPropertyNative,
+        CGSSetConnectionPropertyDart>('CGSSetConnectionProperty');
+
+    final cfStringCreate = coreFoundation.lookupFunction<
+        CFStringCreateWithCStringNative,
+        CFStringCreateWithCStringDart>('CFStringCreateWithCString');
+
+    final kCFBooleanTruePtr = coreFoundation.lookup<Pointer>('kCFBooleanTrue');
+    final kCFBooleanTrue = kCFBooleanTruePtr.value;
+
+    final keyStr = 'SetsCursorInBackground'.toNativeUtf8();
+    final cfKey = cfStringCreate(nullptr, keyStr, 0x08000100);
+    cgsSetConnectionProperty(
+        _connectionId, _connectionId, cfKey, kCFBooleanTrue);
+    print('Enabled SetsCursorInBackground');
+
+    _setCursor = coreGraphics.lookupFunction<CGSSetSystemDefinedCursorNative,
+        CGSSetSystemDefinedCursorDart>('CGSSetSystemDefinedCursor');
+
+    // Enable raw mode
+    stdin.echoMode = false;
+    stdin.lineMode = false;
+
+    // Enable focus reporting: CSI ? 1004 h
+    stdout.write('\x1b[?1004h');
+    print('Enabled focus reporting (ESC[?1004h)');
+    print('');
+    print('When you switch tabs/windows, the terminal will send:');
+    print('  Focus IN:  ESC [ I');
+    print('  Focus OUT: ESC [ O');
+    print('');
+
+    print('--- Interactive Mode ---');
+    print('Press keys to change cursor:');
+    print('  a = arrow    t = I-beam    w = wait');
+    print('  q = quit');
+    print('');
+    print('Try: Set a cursor, switch Warp tabs, switch back!');
+    print('The cursor should be reapplied when you return.\n');
+
+    // Buffer for parsing escape sequences
+    final buffer = <int>[];
+    bool inEscape = false;
+
+    await for (final input in stdin) {
+      for (final byte in input) {
+        // Check for escape sequence start
+        if (byte == 0x1b) {
+          inEscape = true;
+          buffer.clear();
+          buffer.add(byte);
+          continue;
+        }
+
+        if (inEscape) {
+          buffer.add(byte);
+
+          // Check for focus sequences: ESC [ I or ESC [ O
+          if (buffer.length >= 3) {
+            final seq = String.fromCharCodes(buffer);
+
+            if (seq == '\x1b[I') {
+              // Focus gained!
+              print('>>> FOCUS IN - Reapplying cursor: $_currentCursorId');
+              _applyCursor();
+              inEscape = false;
+              buffer.clear();
+              continue;
+            } else if (seq == '\x1b[O') {
+              // Focus lost
+              print('>>> FOCUS OUT');
+              inEscape = false;
+              buffer.clear();
+              continue;
+            }
+          }
+
+          // Give up on escape after 10 bytes
+          if (buffer.length > 10) {
+            inEscape = false;
+            buffer.clear();
+          }
+          continue;
+        }
+
+        // Regular key handling
+        final char = String.fromCharCode(byte);
+
+        if (char == 'q') {
+          // Cleanup
+          stdout.write('\x1b[?1004l'); // Disable focus reporting
+          _setCursor?.call(_connectionId, CGSCursor.arrow);
+          stdin.echoMode = true;
+          stdin.lineMode = true;
+          print('\nDisabled focus reporting. Goodbye!');
+          return;
+        }
+
+        switch (char) {
+          case 'a':
+            _currentCursorId = CGSCursor.arrow;
+            _applyCursor();
+            print('Set to arrow');
+          case 't':
+            _currentCursorId = CGSCursor.iBeam;
+            _applyCursor();
+            print('Set to I-beam');
+          case 'w':
+            _currentCursorId = CGSCursor.wait;
+            _applyCursor();
+            print('Set to wait');
+        }
+      }
+    }
+  } catch (e, stack) {
+    print('Error: $e');
+    print(stack);
+  }
+}
+
+void _applyCursor() {
+  _setCursor?.call(_connectionId, _currentCursorId);
+}

--- a/example/cursor_shape_demo.dart
+++ b/example/cursor_shape_demo.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+/// Demo script to test cursor shape escape sequences (DECSCUSR)
+///
+/// Run with: dart run example/cursor_shape_demo.dart
+void main() async {
+  // Enable raw mode for better control
+  stdin.echoMode = false;
+  stdin.lineMode = false;
+
+  print('Cursor Shape Demo (DECSCUSR)');
+  print('============================\n');
+  print('Watch the cursor shape change!\n');
+
+  final shapes = [
+    (1, 'Blinking Block'),
+    (2, 'Steady Block'),
+    (3, 'Blinking Underline'),
+    (4, 'Steady Underline'),
+    (5, 'Blinking Bar (I-beam)'),
+    (6, 'Steady Bar (I-beam)'),
+  ];
+
+  for (final (code, name) in shapes) {
+    // Set cursor shape: ESC [ N SP q
+    stdout.write('\x1b[$code q');
+    stdout.write('Cursor style $code: $name');
+    stdout.write(' <-- Look at the cursor here');
+    print('');
+
+    // Wait a bit so you can see each shape
+    await Future.delayed(Duration(seconds: 2));
+  }
+
+  print('\n--- Interactive Mode ---');
+  print('Press 1-6 to change cursor, q to quit:\n');
+
+  // Reset to blinking block
+  stdout.write('\x1b[1 q');
+
+  // Listen for keypresses
+  await for (final input in stdin) {
+    final char = String.fromCharCode(input.first);
+
+    if (char == 'q') {
+      break;
+    }
+
+    final code = int.tryParse(char);
+    if (code != null && code >= 1 && code <= 6) {
+      stdout.write('\x1b[$code q');
+      print('Changed to style $code: ${shapes[code - 1].$2}');
+    }
+  }
+
+  // Reset cursor to default and restore terminal
+  stdout.write('\x1b[0 q'); // Reset to default
+  stdin.echoMode = true;
+  stdin.lineMode = true;
+
+  print('\nCursor reset to default. Goodbye!');
+}

--- a/example/mouse_pointer_demo.dart
+++ b/example/mouse_pointer_demo.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+/// Demo script to test mouse pointer cursor shape escape sequences (OSC 22)
+///
+/// This works in Kitty and some other modern terminals.
+/// May NOT work in: basic xterm, macOS Terminal.app, older terminals
+///
+/// Run with: dart run example/mouse_pointer_demo.dart
+void main() async {
+  // Enable raw mode
+  stdin.echoMode = false;
+  stdin.lineMode = false;
+
+  print('Mouse Pointer Shape Demo (OSC 22)');
+  print('==================================\n');
+  print('NOTE: This only works in Kitty and some modern terminals!\n');
+  print(
+      'Move your mouse over this terminal window to see the pointer change.\n');
+
+  // Common pointer shapes (CSS-based names)
+  final shapes = [
+    'default', // Normal arrow
+    'pointer', // Hand/link cursor
+    'text', // I-beam for text
+    'crosshair', // Crosshair/precision
+    'move', // Move cursor
+    'grab', // Open hand (ready to grab)
+    'grabbing', // Closed hand (grabbing)
+    'not-allowed', // Circle with slash
+    'wait', // Hourglass/spinner
+    'progress', // Arrow with spinner
+    'help', // Arrow with question mark
+    'cell', // Cell/plus cursor
+    'copy', // Arrow with plus
+    'zoom-in', // Magnifier with plus
+    'zoom-out', // Magnifier with minus
+    'e-resize', // East resize arrow
+    'ns-resize', // North-south resize
+    'nwse-resize', // Diagonal resize
+  ];
+
+  for (final shape in shapes) {
+    // Set pointer shape: OSC 22 ; shape ST
+    // OSC = ESC ]
+    // ST = ESC \
+    stdout.write('\x1b]22;$shape\x1b\\');
+
+    print('Pointer: "$shape" - move mouse over terminal to see');
+    await Future.delayed(Duration(seconds: 2));
+  }
+
+  print('\n--- Interactive Mode ---');
+  print('Press keys to change pointer:');
+  print('  d = default (arrow)');
+  print('  p = pointer (hand)');
+  print('  t = text (I-beam)');
+  print('  c = crosshair');
+  print('  g = grab');
+  print('  m = move');
+  print('  w = wait');
+  print('  n = not-allowed');
+  print('  q = quit\n');
+
+  // Reset to default
+  stdout.write('\x1b]22;default\x1b\\');
+
+  await for (final input in stdin) {
+    final char = String.fromCharCode(input.first);
+
+    String? shape;
+    switch (char) {
+      case 'd':
+        shape = 'default';
+      case 'p':
+        shape = 'pointer';
+      case 't':
+        shape = 'text';
+      case 'c':
+        shape = 'crosshair';
+      case 'g':
+        shape = 'grab';
+      case 'm':
+        shape = 'move';
+      case 'w':
+        shape = 'wait';
+      case 'n':
+        shape = 'not-allowed';
+      case 'q':
+        break;
+    }
+
+    if (char == 'q') break;
+
+    if (shape != null) {
+      stdout.write('\x1b]22;$shape\x1b\\');
+      print('Changed to: $shape');
+    }
+  }
+
+  // Reset pointer and terminal
+  stdout.write('\x1b]22;default\x1b\\');
+  stdin.echoMode = true;
+  stdin.lineMode = true;
+
+  print('\nPointer reset to default. Goodbye!');
+}

--- a/example/native_cursor_demo.dart
+++ b/example/native_cursor_demo.dart
@@ -1,0 +1,113 @@
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/ffi.dart';
+
+/// Proof-of-concept: Can we control the mouse cursor from a CLI app via FFI?
+///
+/// This explores using macOS native APIs to change the cursor system-wide,
+/// bypassing terminal escape sequence limitations.
+///
+/// Run with: dart run example/native_cursor_demo.dart
+
+// objc_msgSend - Send a message to an Objective-C object
+typedef ObjcMsgSendNoArgsC = Pointer Function(Pointer obj, Pointer sel);
+typedef ObjcMsgSendNoArgsDart = Pointer Function(Pointer obj, Pointer sel);
+
+void main() async {
+  print('Native Cursor Control Demo (macOS FFI)');
+  print('=======================================\n');
+
+  if (!Platform.isMacOS) {
+    print('This demo only works on macOS');
+    return;
+  }
+
+  try {
+    // Get the objc runtime functions
+    final libobjc = DynamicLibrary.open('/usr/lib/libobjc.A.dylib');
+
+    final objc_getClass = libobjc.lookupFunction<
+        Pointer Function(Pointer<Utf8> name),
+        Pointer Function(Pointer<Utf8> name)>('objc_getClass');
+
+    final sel_registerName = libobjc.lookupFunction<
+        Pointer Function(Pointer<Utf8> name),
+        Pointer Function(Pointer<Utf8> name)>('sel_registerName');
+
+    final objc_msgSend =
+        libobjc.lookupFunction<ObjcMsgSendNoArgsC, ObjcMsgSendNoArgsDart>(
+            'objc_msgSend');
+
+    // Helper to create a selector
+    Pointer sel(String name) => sel_registerName(name.toNativeUtf8());
+
+    // Helper to get a class
+    Pointer cls(String name) => objc_getClass(name.toNativeUtf8());
+
+    print('Step 1: Getting NSCursor class...');
+    final nsCursorClass = cls('NSCursor');
+    print(
+        '  NSCursor class: ${nsCursorClass.address != 0 ? "FOUND" : "NOT FOUND"}');
+    if (nsCursorClass.address == 0) {
+      print(
+          '  -> NSCursor requires AppKit, which may not be loaded in CLI context');
+    }
+
+    print('\nStep 2: Getting cursor instances...');
+    final cursors = [
+      'arrowCursor',
+      'IBeamCursor',
+      'crosshairCursor',
+      'pointingHandCursor'
+    ];
+    for (final name in cursors) {
+      final cursor = objc_msgSend(nsCursorClass, sel(name));
+      print(
+          '  $name: ${cursor.address != 0 ? "OK (${cursor.address})" : "null"}');
+    }
+
+    print('\nStep 3: Trying to hide/show system cursor...');
+    // Try class methods to hide/show cursor
+    objc_msgSend(nsCursorClass, sel('hide'));
+    print('  Called [NSCursor hide]');
+
+    await Future.delayed(Duration(seconds: 2));
+
+    objc_msgSend(nsCursorClass, sel('unhide'));
+    print('  Called [NSCursor unhide]');
+
+    print('\nStep 4: Interactive test...');
+    print('Move your mouse around. Did the cursor hide for 2 seconds?');
+    print('');
+    print('Press Enter to try setting cursor to I-beam...');
+    stdin.readLineSync();
+
+    final ibeam = objc_msgSend(nsCursorClass, sel('IBeamCursor'));
+    if (ibeam.address != 0) {
+      objc_msgSend(ibeam, sel('set'));
+      print('Called [IBeamCursor set]');
+      print('');
+      print(
+          'Did the cursor change? (Likely not - we\'re not the frontmost app!)');
+    }
+
+    print('\n--- ANALYSIS ---');
+    print(
+        'The challenge: NSCursor methods only work when YOUR app is frontmost.');
+    print(
+        'But WE are running inside Terminal.app/Warp/Kitty, so THEY are frontmost.');
+    print('');
+    print('Possible workarounds:');
+    print(
+        '1. Use private CGS APIs (like screencapture does) - not App Store safe');
+    print('2. Find a way to tell the terminal app to change its cursor');
+    print('3. Use OSC 22 escape sequences (Kitty/modern terminals only)');
+    print('');
+    print('The terminal IS the window owner, so it controls the cursor.');
+  } catch (e, stack) {
+    print('Error: $e');
+    print(stack);
+  }
+
+  print('\nDone!');
+}

--- a/test/input/mouse_scroll_exploration_test.dart
+++ b/test/input/mouse_scroll_exploration_test.dart
@@ -1,0 +1,711 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+/// Exploration tests to understand current mouse support behavior and identify issues.
+/// This file documents the current state of mouse support for planning improvements.
+void main() {
+  group('Mouse Wheel Scrolling - ListView', () {
+    test('basic wheel scroll down in ListView', () async {
+      await testNocterm(
+        'ListView wheel scroll down',
+        (tester) async {
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 50,
+                itemBuilder: (context, index) => Text('Item $index'),
+              ),
+            ),
+          );
+
+          expect(tester.terminalState, containsText('Item 0'));
+          expect(controller.offset, 0);
+
+          // Send wheel down event at position inside the ListView
+          await tester.sendMouseEvent(MouseEvent(
+            button: MouseButton.wheelDown,
+            x: 20,
+            y: 5,
+            pressed: true, // Wheel events use pressed=true
+          ));
+
+          // Should have scrolled down by 3 lines
+          expect(controller.offset, 3);
+          expect(tester.terminalState, containsText('Item 3'));
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+
+    test('wheel scroll up in ListView', () async {
+      await testNocterm(
+        'ListView wheel scroll up',
+        (tester) async {
+          final controller = ScrollController(initialScrollOffset: 10);
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 50,
+                itemBuilder: (context, index) => Text('Item $index'),
+              ),
+            ),
+          );
+
+          expect(controller.offset, 10);
+
+          // Send wheel up event
+          await tester.sendMouseEvent(MouseEvent(
+            button: MouseButton.wheelUp,
+            x: 20,
+            y: 5,
+            pressed: true,
+          ));
+
+          // Should have scrolled up by 3 lines
+          expect(controller.offset, 7);
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+
+    test('wheel scroll respects boundaries', () async {
+      await testNocterm(
+        'ListView scroll boundaries',
+        (tester) async {
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                controller: controller,
+                itemCount:
+                    5, // Only 5 items, content may be shorter than viewport
+                itemBuilder: (context, index) => Text('Item $index'),
+              ),
+            ),
+          );
+
+          // Try to scroll up when already at top
+          await tester.sendMouseEvent(MouseEvent(
+            button: MouseButton.wheelUp,
+            x: 20,
+            y: 5,
+            pressed: true,
+          ));
+
+          expect(controller.offset, 0, reason: 'Should not scroll past top');
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+  });
+
+  group('Mouse Wheel Scrolling - SingleChildScrollView', () {
+    test('basic wheel scroll in SingleChildScrollView', () async {
+      await testNocterm(
+        'SCSV wheel scroll',
+        (tester) async {
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: SingleChildScrollView(
+                controller: controller,
+                child: Column(
+                  children: List.generate(30, (i) => Text('Line $i')),
+                ),
+              ),
+            ),
+          );
+
+          expect(controller.offset, 0);
+
+          // Send wheel down
+          await tester.sendMouseEvent(MouseEvent(
+            button: MouseButton.wheelDown,
+            x: 20,
+            y: 5,
+            pressed: true,
+          ));
+
+          expect(controller.offset, 3);
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+
+    test('horizontal scroll with wheel', () async {
+      await testNocterm(
+        'horizontal SCSV wheel scroll',
+        (tester) async {
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 20,
+              height: 5,
+              child: SingleChildScrollView(
+                controller: controller,
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    Text(
+                        'This is a very long text that needs horizontal scrolling'),
+                  ],
+                ),
+              ),
+            ),
+          );
+
+          expect(controller.offset, 0);
+
+          // Wheel down should scroll horizontally
+          await tester.sendMouseEvent(MouseEvent(
+            button: MouseButton.wheelDown,
+            x: 10,
+            y: 2,
+            pressed: true,
+          ));
+
+          expect(controller.offset, 3);
+        },
+        debugPrintAfterPump: true,
+        size: Size(30, 10),
+      );
+    });
+  });
+
+  group('Mouse Click/Tap in Scrollable Lists', () {
+    test('tap on item in ListView', () async {
+      await testNocterm(
+        'tap ListView item',
+        (tester) async {
+          int? tappedIndex;
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                itemCount: 20,
+                itemBuilder: (context, index) => GestureDetector(
+                  onTap: () => tappedIndex = index,
+                  child: Container(
+                    height: 1,
+                    child: Text('Tappable Item $index'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          // Tap on item at y=3 (should be item 3)
+          await tester.tap(20, 3);
+
+          expect(tappedIndex, 3);
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+
+    test('tap on item after scrolling ListView', () async {
+      await testNocterm(
+        'tap after scroll',
+        (tester) async {
+          int? tappedIndex;
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 50,
+                itemBuilder: (context, index) => GestureDetector(
+                  onTap: () => tappedIndex = index,
+                  child: Container(
+                    height: 1,
+                    child: Text('Item $index'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          // Scroll down first
+          controller.scrollDown(10);
+          await tester.pump();
+
+          // Now tap on visual y=3 - should be item 13 (10 + 3)
+          await tester.tap(20, 3);
+
+          // POTENTIAL BUG: Hit testing may not account for scroll offset
+          expect(tappedIndex, 13,
+              reason:
+                  'After scrolling 10 items, tap at y=3 should hit item 13');
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+
+    test('tap on partially visible item', () async {
+      await testNocterm(
+        'tap partial item',
+        (tester) async {
+          int? tappedIndex;
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 50,
+                itemBuilder: (context, index) => GestureDetector(
+                  onTap: () => tappedIndex = index,
+                  child: Container(
+                    height: 2, // 2-line items
+                    child: Text('Two-line Item $index'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          // Scroll by 1 line so items are partially visible
+          controller.jumpTo(1);
+          await tester.pump();
+
+          // Tap at y=0 - should hit item 0 or item 1?
+          await tester.tap(20, 0);
+
+          // Document actual behavior
+          print('Tapped index after partial scroll: $tappedIndex');
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+  });
+
+  group('Mouse Hover in Scrollable Lists', () {
+    test('hover tracking in ListView', () async {
+      await testNocterm(
+        'ListView hover',
+        (tester) async {
+          int? hoveredIndex;
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                itemCount: 20,
+                itemBuilder: (context, index) => MouseRegion(
+                  onEnter: (_) => hoveredIndex = index,
+                  child: Container(
+                    height: 1,
+                    child: Text('Hoverable Item $index'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          // Hover over y=5
+          await tester.hover(20, 5);
+
+          expect(hoveredIndex, 5);
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+
+    test('hover after scroll - position mapping', () async {
+      await testNocterm(
+        'hover after scroll',
+        (tester) async {
+          int? hoveredIndex;
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 50,
+                itemBuilder: (context, index) => MouseRegion(
+                  onEnter: (_) => hoveredIndex = index,
+                  child: Container(
+                    height: 1,
+                    child: Text('Item $index'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          // Scroll down 10 items
+          controller.scrollDown(10);
+          await tester.pump();
+
+          // Hover at y=2
+          await tester.hover(20, 2);
+
+          // POTENTIAL BUG: hover position may not account for scroll
+          expect(hoveredIndex, 12,
+              reason:
+                  'After scrolling 10 items, hover at y=2 should hit item 12');
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+  });
+
+  group('Mouse Drag/Selection in Lists', () {
+    test('mouse drag creates motion events', () async {
+      await testNocterm(
+        'drag motion events',
+        (tester) async {
+          final motionEvents = <MouseEvent>[];
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: MouseRegion(
+                onHover: (event) {
+                  if (event.isMotion) {
+                    motionEvents.add(event);
+                  }
+                },
+                child: Container(
+                  width: 40,
+                  height: 10,
+                  child: Text('Drag area'),
+                ),
+              ),
+            ),
+          );
+
+          // Perform a drag
+          await tester.mouseMove(5, 2, 35, 8);
+
+          // Check if motion events were captured
+          print('Captured ${motionEvents.length} motion events');
+          for (final event in motionEvents) {
+            print(
+                '  Motion: (${event.x}, ${event.y}) pressed=${event.pressed} isMotion=${event.isMotion}');
+          }
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+
+    test('drag detection in GestureDetector - no pan support yet', () async {
+      await testNocterm(
+        'no pan gesture',
+        (tester) async {
+          // GestureDetector currently doesn't support onPan/onDrag
+          // This test documents the missing functionality
+
+          bool tapDetected = false;
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: GestureDetector(
+                onTap: () => tapDetected = true,
+                // onPanStart: ... // NOT SUPPORTED
+                // onPanUpdate: ... // NOT SUPPORTED
+                // onPanEnd: ... // NOT SUPPORTED
+                child: Container(
+                  width: 40,
+                  height: 10,
+                  child: Text('No pan support'),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(20, 5);
+          expect(tapDetected, isTrue);
+
+          // NOTE: Drag selection would require onPan gestures
+          // which are not yet implemented
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 15),
+      );
+    });
+  });
+
+  group('Mouse Events in Nested Scrollables', () {
+    test('wheel scroll in nested scroll views', () async {
+      await testNocterm(
+        'nested scroll wheel',
+        (tester) async {
+          final outerController = ScrollController();
+          final innerController = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 15,
+              child: SingleChildScrollView(
+                controller: outerController,
+                child: Column(
+                  children: [
+                    Text('Outer header'),
+                    Container(
+                      height: 8,
+                      child: ListView.builder(
+                        controller: innerController,
+                        itemCount: 20,
+                        itemBuilder: (context, index) => Text('Inner $index'),
+                      ),
+                    ),
+                    for (int i = 0; i < 20; i++) Text('Outer item $i'),
+                  ],
+                ),
+              ),
+            ),
+          );
+
+          // Wheel inside inner ListView area (y=2 to y=9)
+          await tester.sendMouseEvent(MouseEvent(
+            button: MouseButton.wheelDown,
+            x: 20,
+            y: 5, // Inside inner list
+            pressed: true,
+          ));
+
+          print('Inner offset: ${innerController.offset}');
+          print('Outer offset: ${outerController.offset}');
+
+          // Document which scrollable receives the event
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 20),
+      );
+    });
+  });
+
+  group('Mouse Position Coordinate System', () {
+    test('verify 0-based coordinates from parser', () async {
+      await testNocterm(
+        'coordinate verification',
+        (tester) async {
+          int? lastX, lastY;
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: MouseRegion(
+                onHover: (event) {
+                  lastX = event.x;
+                  lastY = event.y;
+                },
+                child: Container(
+                  width: 40,
+                  height: 10,
+                  child: Text('Click test'),
+                ),
+              ),
+            ),
+          );
+
+          // Hover at terminal position (0,0)
+          await tester.hover(0, 0);
+          expect(lastX, 0, reason: 'x should be 0-based');
+          expect(lastY, 0, reason: 'y should be 0-based');
+
+          // Hover at (10, 5)
+          await tester.hover(10, 5);
+          expect(lastX, 10);
+          expect(lastY, 5);
+        },
+        size: Size(50, 15),
+      );
+    });
+
+    test('hit test with offset containers', () async {
+      await testNocterm(
+        'offset container hit test',
+        (tester) async {
+          bool boxHit = false;
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 20,
+              child: Stack(
+                children: [
+                  Positioned(
+                    left: 10,
+                    top: 5,
+                    child: GestureDetector(
+                      onTap: () => boxHit = true,
+                      child: Container(
+                        width: 15,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          border: BoxBorder.all(color: Colors.red),
+                        ),
+                        child: Text('Target'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+
+          // Tap inside the positioned box (10+7, 5+4)
+          await tester.tap(17, 9);
+          expect(boxHit, isTrue, reason: 'Should hit positioned box');
+
+          boxHit = false;
+
+          // Tap outside the positioned box
+          await tester.tap(5, 5);
+          expect(boxHit, isFalse, reason: 'Should miss positioned box');
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 25),
+      );
+    });
+  });
+
+  group('Regression: Known Issues', () {
+    test('ISSUE: scroll position not updating hit test', () async {
+      // This test explores potential scroll+hit test issues
+      await testNocterm(
+        'scroll hit test sync',
+        (tester) async {
+          final taps = <int>[];
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 8,
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 30,
+                itemBuilder: (context, index) => GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () {
+                    taps.add(index);
+                    print('Tapped item $index');
+                  },
+                  child: Container(
+                    height: 1,
+                    child: Text('[$index] Tap me'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          // Tap first visible item
+          await tester.tap(20, 0);
+          print('After first tap, taps=$taps');
+
+          // Scroll down
+          for (int i = 0; i < 5; i++) {
+            await tester.sendMouseEvent(MouseEvent(
+              button: MouseButton.wheelDown,
+              x: 20,
+              y: 4,
+              pressed: true,
+            ));
+          }
+          print('After scrolling, offset=${controller.offset}');
+
+          // Tap at same visual position
+          await tester.tap(20, 0);
+          print('After second tap, taps=$taps');
+
+          // The second tap should hit a different item than the first
+          if (taps.length == 2) {
+            expect(taps[0] != taps[1], isTrue,
+                reason:
+                    'Same visual position should hit different items after scroll');
+          }
+        },
+        debugPrintAfterPump: true,
+        size: Size(50, 12),
+      );
+    });
+
+    test('ISSUE: rapid scroll wheel events', () async {
+      // Test if rapid wheel events are handled correctly
+      await testNocterm(
+        'rapid wheel events',
+        (tester) async {
+          final controller = ScrollController();
+
+          await tester.pumpComponent(
+            Container(
+              width: 40,
+              height: 10,
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 100,
+                itemBuilder: (context, index) => Text('Item $index'),
+              ),
+            ),
+          );
+
+          final startOffset = controller.offset;
+
+          // Send many rapid wheel events
+          for (int i = 0; i < 10; i++) {
+            await tester.sendMouseEvent(MouseEvent(
+              button: MouseButton.wheelDown,
+              x: 20,
+              y: 5,
+              pressed: true,
+            ));
+          }
+
+          final expectedOffset = startOffset + (10 * 3); // 3 lines per wheel
+          print(
+              'Expected offset: $expectedOffset, actual: ${controller.offset}');
+
+          expect(controller.offset, expectedOffset,
+              reason: 'All wheel events should be processed');
+        },
+        size: Size(50, 15),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Explore options for controlling mouse pointer cursor from TUI apps:

- OSC 22 escape sequences (Kitty/modern terminals)
- CGS private APIs for system-wide cursor control (macOS)
- DECSCUSR for text cursor shape
- Focus tracking with xterm focus reporting

Includes:
- docs/mouse_cursor_research.md - comprehensive summary
- example/cgs_cursor_demo.dart - CGS private API demo
- example/cgs_cursor_focus_demo.dart - CGS with focus tracking
- example/cursor_shape_demo.dart - text cursor (DECSCUSR)
- example/mouse_pointer_demo.dart - OSC 22 demo
- example/native_cursor_demo.dart - initial FFI exploration
- test/input/mouse_scroll_exploration_test.dart - mouse behavior tests

Key findings:
- OSC 22 works in Kitty but not Warp
- CGS SetsCursorInBackground trick works system-wide
- Cursor resets on tab switch, needs focus tracking to reapply