### PR TITLE
fix: render object attach

### DIFF
--- a/lib/src/framework/render_object.dart
+++ b/lib/src/framework/render_object.dart
@@ -521,6 +521,9 @@ abstract class RenderObject {
   void adoptChild(RenderObject child) {
     setupParentData(child);
     child.parent = this;
+    if (owner != null) {
+      child.attach(owner!);
+    }
     markNeedsLayout();
   }
 


### PR DESCRIPTION
Working on utilizing SelectionArea from #40 in my TUI app, Cow. It has two panes and when I wrapped their contents with `SelectionArea`'s, no selections would appear.

Claude did some serious digging for quite some time and realized this was the issue. It said it needed to do what Flutter's `adoptChild` was doing and showed me this: https://github.com/flutter/flutter/blob/ddd957bb2a6c0b70b2f2ff348aa5211fd83b97f7/packages/flutter/lib/src/rendering/object.dart#L2042

https://github.com/user-attachments/assets/6f3964d8-7551-4a57-a44b-f46a4a704660

Can confirm this fixes the selection issue.