### PR TITLE
fix: Cancel pendingFrameTimer on shutdown

### DIFF
--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -515,6 +515,7 @@ class TerminalBinding extends NoctermBinding
     _shouldExit = true;
 
     // Cancel all subscriptions immediately
+    pendingFrameTimer?.cancel();
     _inputSubscription?.cancel();
     _resizeSubscription?.cancel();
     _shutdownSubscription?.cancel();


### PR DESCRIPTION
To avoid stray output from animation after shutdown called