### PR TITLE
fix(selection): use screen position sorting for all viewports

### DIFF
--- a/lib/src/components/selection_area.dart
+++ b/lib/src/components/selection_area.dart
@@ -631,21 +631,8 @@ class RenderSelectionArea extends RenderMouseRegion {
       lists.putIfAbsent(contextKey, () => []).add(entry);
     }
 
-    for (final entry in lists.entries) {
-      final context = entry.key;
-      final list = entry.value;
-      if (context is RenderListViewport) {
-        list.sort((a, b) {
-          final aIdx = a.listIndex;
-          final bIdx = b.listIndex;
-          if (aIdx != null && bIdx != null && aIdx != bIdx) {
-            return aIdx.compareTo(bIdx);
-          }
-          return _compareByPosition(a, b);
-        });
-      } else {
-        list.sort(_compareByPosition);
-      }
+    for (final list in lists.values) {
+      list.sort(_compareByPosition);
     }
 
     _contextListsCache = lists;


### PR DESCRIPTION
## Summary
- Fixed text selection flipping/inverting when dragging across items in a reversed ListView
- Removed special `listIndex`-based sorting for `RenderListViewport` contexts in `SelectionArea`

## Problem
`SelectionArea._buildContextLists()` sorted selectables by `listIndex` when inside a `RenderListViewport`. In a reversed ListView, ascending `listIndex` order is the opposite of visual (screen) order. This caused the `forward` boolean in `_updateSelectionRanges` to be computed incorrectly when a drag crossed item boundaries, flipping the selection direction.

## Fix
Since `RenderListViewport` already transforms child coordinates to screen space during layout (the reverse flip at `list_view.dart:932-934`), position-based sorting (`bounds.top`) is always correct regardless of list direction. The `listIndex`-based special case was unnecessary and harmful for reversed lists.

## Test plan
- [ ] Drag-select across multiple items in a reversed ListView — selection should grow continuously without flipping
- [ ] Drag-select across different fragment types (text → tool call → text) in reversed ListView
- [ ] Verify normal (non-reversed) ListView selection still works correctly
- [ ] Test both forward and backward drag directions