### PR TITLE
Fix: update landing page version during release

### DIFF
--- a/justfile
+++ b/justfile
@@ -82,8 +82,13 @@ release:
             sed -i '' -E "s/nocterm: \^[0-9]+\.[0-9]+\.[0-9]+/nocterm: ^$version_number/" README.md
             sed -i '' -E "s/in early development \([0-9]+\.[0-9]+\.[0-9]+\)/in early development ($version_number)/" README.md
 
+            # Update version on the landing page
+            echo "Updating landing/index.html..."
+            sed -i '' -E "s/brand-version\">v[0-9]+\.[0-9]+\.[0-9]+/brand-version\">v$version_number/" landing/index.html
+            sed -i '' -E "s/\"softwareVersion\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"softwareVersion\": \"$version_number\"/" landing/index.html
+
             # Commit the version bump
-            git add pubspec.yaml README.md
+            git add pubspec.yaml README.md landing/index.html
             git commit -m "chore: bump version to $version_number"
 
             # Push the commit

--- a/landing/index.html
+++ b/landing/index.html
@@ -739,7 +739,7 @@
         <div class="brand">
           <span class="brand-icon">✦</span>
           <span class="brand-name">Nocterm</span>
-          <span class="brand-version">v0.4.2</span>
+          <span class="brand-version">v0.5.0</span>
         </div>
         <div class="wave-container" id="wave" aria-hidden="true"></div>
         <nav class="bottom-links">
@@ -770,7 +770,7 @@
         "programmingLanguage": "Dart",
         "url": "https://nocterm.dev",
         "downloadUrl": "https://pub.dev/packages/nocterm",
-        "softwareVersion": "0.4.2",
+        "softwareVersion": "0.5.0",
         "author": {
           "@type": "Organization",
           "name": "Nocterm"


### PR DESCRIPTION
## Summary
- The `just release` recipe now also updates the version on the landing page (`landing/index.html`) — both the footer badge and the structured data `softwareVersion` field.
- Updates the landing page version from the stale `v0.4.2` to the current `v0.5.0`.

Fixes https://github.com/Norbert515/nocterm/issues/51

## Changes
- **`justfile`**: Added two `sed` commands to update `landing/index.html` and included it in the `git add` step.
- **`landing/index.html`**: Updated version from `0.4.2` to `0.5.0` in the footer badge and JSON-LD structured data.