### PR TITLE
Ironing a Markdown alternative

### DIFF
--- a/lib/src/components/markdown_component.dart
+++ b/lib/src/components/markdown_component.dart
@@ -1,0 +1,683 @@
+import 'package:dart_markdown_parser/dart_markdown_parser.dart';
+import 'package:highlight/highlight.dart' show highlight, Node;
+import 'package:nocterm/nocterm.dart';
+
+/// Maps highlight.js token class names to terminal text styles.
+///
+/// Token classes: keyword, string, comment, number, built_in, title,
+/// type, literal, attr, meta, tag, name, selector-class, etc.
+class SyntaxTheme {
+  const SyntaxTheme({
+    this.keyword = const TextStyle(color: Colors.magenta, fontWeight: FontWeight.bold),
+    this.string = const TextStyle(color: Colors.green),
+    this.comment = const TextStyle(color: Colors.grey, fontStyle: FontStyle.italic),
+    this.number = const TextStyle(color: Colors.cyan),
+    this.builtIn = const TextStyle(color: Colors.blue),
+    this.title = const TextStyle(color: Colors.brightBlue, fontWeight: FontWeight.bold),
+    this.type = const TextStyle(color: Colors.blue, fontWeight: FontWeight.bold),
+    this.literal = const TextStyle(color: Colors.cyan),
+    this.attr = const TextStyle(color: Colors.cyan),
+    this.meta = const TextStyle(color: Colors.grey),
+    this.tag = const TextStyle(color: Colors.red),
+    this.name = const TextStyle(color: Colors.red),
+    this.operator = const TextStyle(color: Colors.white),
+    this.punctuation = const TextStyle(color: Colors.grey),
+    this.variable = const TextStyle(color: Colors.brightRed),
+    this.symbol = const TextStyle(color: Colors.cyan),
+    this.fallback,
+  });
+
+  final TextStyle keyword;
+  final TextStyle string;
+  final TextStyle comment;
+  final TextStyle number;
+  final TextStyle builtIn;
+  final TextStyle title;
+  final TextStyle type;
+  final TextStyle literal;
+  final TextStyle attr;
+  final TextStyle meta;
+  final TextStyle tag;
+  final TextStyle name;
+  final TextStyle operator;
+  final TextStyle punctuation;
+  final TextStyle variable;
+  final TextStyle symbol;
+
+  /// Fallback style for unrecognized token classes (null = inherit).
+  final TextStyle? fallback;
+
+  TextStyle? styleFor(String className) => switch (className) {
+        'keyword' || 'selector-tag' => keyword,
+        'string' || 'regexp' || 'addition' => string,
+        'comment' || 'quote' || 'deletion' => comment,
+        'number' => number,
+        'built_in' || 'builtin-name' => builtIn,
+        'title' || 'function' => title,
+        'type' || 'class' => type,
+        'literal' => literal,
+        'attr' || 'attribute' || 'selector-attr' => attr,
+        'meta' || 'meta-string' => meta,
+        'tag' => tag,
+        'name' || 'selector-id' || 'selector-class' => name,
+        'operator' || 'code' => operator,
+        'punctuation' || 'template-tag' || 'template-variable' => punctuation,
+        'variable' || 'params' => variable,
+        'symbol' || 'bullet' || 'link' => symbol,
+        _ => fallback,
+      };
+}
+
+/// Stylesheet for rendering markdown AST nodes as terminal rich text.
+class MDownStyleSheet {
+  const MDownStyleSheet({
+    this.h1Style = const TextStyle(fontWeight: FontWeight.bold, color: Colors.cyan),
+    this.h2Style = const TextStyle(fontWeight: FontWeight.bold, color: Colors.blue),
+    this.h3Style = const TextStyle(fontWeight: FontWeight.bold, color: Colors.green),
+    this.h4Style = const TextStyle(fontWeight: FontWeight.bold),
+    this.h5Style = const TextStyle(fontWeight: FontWeight.bold),
+    this.h6Style = const TextStyle(fontWeight: FontWeight.bold, fontStyle: FontStyle.italic),
+    this.boldStyle = const TextStyle(fontWeight: FontWeight.bold),
+    this.italicStyle = const TextStyle(fontStyle: FontStyle.italic),
+    this.strikethroughStyle = const TextStyle(decoration: TextDecoration.lineThrough),
+    this.codeStyle = const TextStyle(color: Colors.yellow, backgroundColor: Colors.black),
+    this.codeBlockStyle = const TextStyle(color: Colors.green, backgroundColor: Colors.black),
+    this.blockquoteStyle = const TextStyle(color: Colors.grey, fontStyle: FontStyle.italic),
+    this.linkStyle = const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
+    this.hashtagStyle = const TextStyle(color: Colors.magenta, fontWeight: FontWeight.bold),
+    this.mentionStyle = const TextStyle(color: Colors.cyan, fontWeight: FontWeight.bold),
+    this.mathStyle = const TextStyle(color: Colors.yellow, fontStyle: FontStyle.italic),
+    this.footnoteRefStyle = const TextStyle(color: Colors.blue, fontWeight: FontWeight.dim),
+    this.listBullet = '• ',
+    this.orderedListSeparator = '. ',
+    this.horizontalRule = '─',
+    this.horizontalRuleWidth = 40,
+    this.taskChecked = '◉ ',
+    this.taskUnchecked = '◎ ',
+    this.syntaxTheme = const SyntaxTheme(),
+    this.diffAddStyle = const TextStyle(color: Colors.green),
+    this.diffDeleteStyle = const TextStyle(color: Colors.red),
+    this.diffImportantStyle = const TextStyle(color: Colors.yellow),
+    this.diffCommentStyle = const TextStyle(color: Colors.grey, fontStyle: FontStyle.italic),
+    this.diffContextStyle,
+  });
+
+  final TextStyle h1Style;
+  final TextStyle h2Style;
+  final TextStyle h3Style;
+  final TextStyle h4Style;
+  final TextStyle h5Style;
+  final TextStyle h6Style;
+  final TextStyle boldStyle;
+  final TextStyle italicStyle;
+  final TextStyle strikethroughStyle;
+  final TextStyle codeStyle;
+  final TextStyle codeBlockStyle;
+  final TextStyle blockquoteStyle;
+  final TextStyle linkStyle;
+  final TextStyle hashtagStyle;
+  final TextStyle mentionStyle;
+  final TextStyle mathStyle;
+  final TextStyle footnoteRefStyle;
+  final String listBullet;
+  final String orderedListSeparator;
+  final String horizontalRule;
+  final int horizontalRuleWidth;
+  final String taskChecked;
+  final String taskUnchecked;
+  final SyntaxTheme syntaxTheme;
+  final TextStyle diffAddStyle;
+  final TextStyle diffDeleteStyle;
+  final TextStyle diffImportantStyle;
+  final TextStyle diffCommentStyle;
+
+  /// Fallback style for unchanged diff context lines (null = codeBlockStyle).
+  final TextStyle? diffContextStyle;
+
+  TextStyle headerStyle(int level) => switch (level) {
+        1 => h1Style,
+        2 => h2Style,
+        3 => h3Style,
+        4 => h4Style,
+        5 => h5Style,
+        _ => h6Style,
+      };
+}
+
+/// Converts dart_markdown_parser AST nodes into nocterm InlineSpan trees.
+class MDownRenderer {
+  MDownRenderer({this.styleSheet = const MDownStyleSheet()});
+
+  final MDownStyleSheet styleSheet;
+  int _listDepth = 0;
+
+  /// Renders a list of top-level AST nodes into InlineSpan list.
+  List<InlineSpan> renderNodes(List<MarkdownNode> nodes) {
+    return [for (final node in nodes) ...renderNode(node)];
+  }
+
+  /// Renders a single node, returning one or more spans.
+  List<InlineSpan> renderNode(MarkdownNode node) => switch (node) {
+        TextNode n => [TextSpan(text: n.content)],
+        HeaderNode n => _renderHeader(n),
+        ParagraphNode n => _renderParagraph(n),
+        BoldNode n => [TextSpan(children: renderNodes(n.children), style: styleSheet.boldStyle)],
+        ItalicNode n => [TextSpan(children: renderNodes(n.children), style: styleSheet.italicStyle)],
+        StrikethroughNode n => [TextSpan(children: renderNodes(n.children), style: styleSheet.strikethroughStyle)],
+        InlineCodeNode n => [TextSpan(text: n.code, style: styleSheet.codeStyle)],
+        CodeBlockNode n => _renderCodeBlock(n),
+        LinkNode n => _renderLink(n),
+        ImageNode n => [
+            TextSpan(
+              text: '[Image: ${n.alt}]',
+              style: const TextStyle(fontStyle: FontStyle.italic),
+            ),
+          ],
+        ListNode n => _renderList(n),
+        ListItemNode n => _renderListItem(n, 0, false),
+        BlockquoteNode n => _renderBlockquote(n),
+        HorizontalRuleNode() => _renderHorizontalRule(),
+        TableNode n => _renderTable(n),
+        InlineMathNode n => [TextSpan(text: '\$${n.latex}\$', style: styleSheet.mathStyle)],
+        BlockMathNode n => [TextSpan(text: '\$\$${n.latex}\$\$\n\n', style: styleSheet.mathStyle)],
+        FootnoteReferenceNode n => [TextSpan(text: '[^${n.label}]', style: styleSheet.footnoteRefStyle)],
+        FootnoteDefinitionNode n => _renderFootnoteDefinition(n),
+        DetailsNode n => _renderDetails(n),
+        HashtagNode n => [TextSpan(text: '#${n.tag}', style: styleSheet.hashtagStyle)],
+        MentionNode n => [TextSpan(text: '@${n.username}', style: styleSheet.mentionStyle)],
+        _ => [TextSpan(text: node.toString())],
+      };
+
+  List<InlineSpan> _renderHeader(HeaderNode node) {
+    final style = styleSheet.headerStyle(node.level);
+    final prefix = '${'#' * node.level} ';
+    final children = node.children != null ? renderNodes(node.children!) : [TextSpan(text: node.content)];
+    return [
+      TextSpan(
+        children: [
+          TextSpan(text: prefix, style: style),
+          ...children,
+          const TextSpan(text: '\n\n'),
+        ],
+        style: style,
+      ),
+    ];
+  }
+
+  List<InlineSpan> _renderParagraph(ParagraphNode node) {
+    return [
+      TextSpan(
+        children: [
+          ...renderNodes(node.children),
+          const TextSpan(text: '\n\n'),
+        ],
+      ),
+    ];
+  }
+
+  List<InlineSpan> _renderCodeBlock(CodeBlockNode node) {
+    final langLabel = node.language != null
+        ? TextSpan(
+            text: '  ${node.language}\n',
+            style: const TextStyle(color: Colors.grey, fontWeight: FontWeight.dim),
+          )
+        : null;
+
+    final codeSpans = _highlightCode(node.code, node.language);
+
+    return [
+      TextSpan(
+        children: [
+          if (langLabel != null) langLabel,
+          ...codeSpans,
+          const TextSpan(text: '\n\n'),
+        ],
+      ),
+    ];
+  }
+
+  List<InlineSpan> _highlightCode(String code, String? language) {
+    if (language == null) {
+      return [TextSpan(text: code, style: styleSheet.codeBlockStyle)];
+    }
+
+    if (language == 'diff' || language == 'git') {
+      return _renderDiff(code);
+    }
+
+    try {
+      final result = highlight.parse(code, language: language);
+      if (result.nodes == null || result.nodes!.isEmpty) {
+        return [TextSpan(text: code, style: styleSheet.codeBlockStyle)];
+      }
+      return _convertNodes(result.nodes!, styleSheet.codeBlockStyle);
+    } catch (_) {
+      return [TextSpan(text: code, style: styleSheet.codeBlockStyle)];
+    }
+  }
+
+  List<InlineSpan> _renderDiff(String code) {
+    final contextStyle = styleSheet.diffContextStyle ?? styleSheet.codeBlockStyle;
+    return code.split('\n').map((line) {
+      final style = switch (line.isEmpty ? ' ' : line[0]) {
+        '+' => styleSheet.diffAddStyle,
+        '-' => styleSheet.diffDeleteStyle,
+        '!' => styleSheet.diffImportantStyle,
+        '#' => styleSheet.diffCommentStyle,
+        _ => contextStyle,
+      };
+      return TextSpan(text: '$line\n', style: style);
+    }).toList();
+  }
+
+  List<InlineSpan> _convertNodes(List<Node> nodes, TextStyle? parentStyle) {
+    return [
+      for (final node in nodes)
+        if (node.value != null)
+          TextSpan(text: node.value, style: parentStyle)
+        else if (node.children != null)
+          TextSpan(
+            children: _convertNodes(
+              node.children!,
+              node.className != null ? styleSheet.syntaxTheme.styleFor(node.className!) : parentStyle,
+            ),
+            style: node.className != null ? styleSheet.syntaxTheme.styleFor(node.className!) : parentStyle,
+          ),
+    ];
+  }
+
+  List<InlineSpan> _renderLink(LinkNode node) {
+    final linkText = renderNodes(node.children);
+    return [
+      TextSpan(
+        children: [
+          ...linkText.map(
+            (s) => s is TextSpan ? TextSpan(text: s.text, children: s.children, style: styleSheet.linkStyle) : s,
+          ),
+          TextSpan(
+            text: ' [${node.url}]',
+            style: styleSheet.linkStyle.copyWith(fontWeight: FontWeight.normal, decoration: TextDecoration.none),
+          ),
+        ],
+      ),
+    ];
+  }
+
+  List<InlineSpan> _renderList(ListNode node) {
+    _listDepth++;
+    final spans = <InlineSpan>[];
+    for (var i = 0; i < node.items.length; i++) {
+      final index = node.ordered ? node.startIndex + i : 0;
+      spans.addAll(_renderListItem(node.items[i], index, node.ordered));
+    }
+    _listDepth--;
+    if (_listDepth == 0) spans.add(const TextSpan(text: '\n'));
+    return spans;
+  }
+
+  List<InlineSpan> _renderListItem(ListItemNode item, int index, bool ordered) {
+    final indent = '  ' * _listDepth;
+    final bullet = item.checked != null
+        ? (item.checked! ? styleSheet.taskChecked : styleSheet.taskUnchecked)
+        : ordered
+            ? '$index${styleSheet.orderedListSeparator}'
+            : styleSheet.listBullet;
+
+    // Build child spans; insert \n before any nested ListNode, and omit the
+    // trailing \n when the last child is a ListNode (it already ends with \n).
+    final childSpans = <InlineSpan>[];
+    bool endsWithList = false;
+    for (final child in item.children) {
+      if (child is ListNode && childSpans.isNotEmpty) {
+        childSpans.add(const TextSpan(text: '\n'));
+      }
+      childSpans.addAll(renderNode(child));
+      endsWithList = child is ListNode;
+    }
+
+    return [
+      TextSpan(
+        children: [
+          TextSpan(text: indent + bullet),
+          ...childSpans,
+          if (!endsWithList) const TextSpan(text: '\n'),
+        ],
+      ),
+    ];
+  }
+
+  List<InlineSpan> _renderBlockquote(BlockquoteNode node) {
+    final inner = renderNodes(node.children);
+    // Insert │ prefix after every newline so multiline blockquotes keep the bar
+    final prefixed = _prefixNewlines(inner, '│ ');
+    return [
+      TextSpan(
+        children: [
+          TextSpan(text: '│ ', style: styleSheet.blockquoteStyle),
+          ...prefixed,
+        ],
+        style: styleSheet.blockquoteStyle,
+      ),
+    ];
+  }
+
+  /// Rewrites TextSpan tree so that every `\n` in text content is followed by [prefix].
+  List<InlineSpan> _prefixNewlines(List<InlineSpan> spans, String prefix) {
+    return [for (final span in spans) _prefixSpan(span, prefix)];
+  }
+
+  InlineSpan _prefixSpan(InlineSpan span, String prefix) {
+    if (span is! TextSpan) return span;
+    final newText = span.text?.replaceAll('\n', '\n$prefix');
+    final newChildren = span.children != null ? _prefixNewlines(span.children!, prefix) : null;
+    return TextSpan(text: newText, children: newChildren, style: span.style);
+  }
+
+  List<InlineSpan> _renderHorizontalRule() {
+    return [
+      TextSpan(
+        text: '${styleSheet.horizontalRule * styleSheet.horizontalRuleWidth}\n\n',
+        style: const TextStyle(color: Colors.grey),
+      ),
+    ];
+  }
+
+  List<InlineSpan> _renderTable(TableNode node) {
+    // Extract all cell texts for width calculation
+    final allRows = <List<String>>[];
+
+    // Headers
+    final headerTexts = node.headers.map((cell) => _plainText(cell)).toList();
+    allRows.add(headerTexts);
+
+    // Data rows
+    for (final row in node.rows) {
+      allRows.add(row.cells.map((cell) => _plainText(cell)).toList());
+    }
+
+    // Calculate column widths
+    final colCount = allRows.fold(0, (max, row) => row.length > max ? row.length : max);
+    final colWidths = List.filled(colCount, 0);
+    for (final row in allRows) {
+      for (var i = 0; i < row.length; i++) {
+        if (row[i].length > colWidths[i]) colWidths[i] = row[i].length;
+      }
+    }
+
+    final buf = StringBuffer();
+
+    // Top border
+    buf.write('┌');
+    for (var i = 0; i < colCount; i++) {
+      buf.write('─' * (colWidths[i] + 2));
+      buf.write(i < colCount - 1 ? '┬' : '┐');
+    }
+    buf.write('\n');
+
+    // Render rows
+    for (var r = 0; r < allRows.length; r++) {
+      buf.write('│');
+      for (var c = 0; c < allRows[r].length; c++) {
+        buf.write(' ');
+        buf.write(allRows[r][c].padRight(colWidths[c]));
+        buf.write(' │');
+      }
+      buf.write('\n');
+
+      // Header separator
+      if (r == 0 && allRows.length > 1) {
+        buf.write('├');
+        for (var i = 0; i < colCount; i++) {
+          buf.write('─' * (colWidths[i] + 2));
+          buf.write(i < colCount - 1 ? '┼' : '┤');
+        }
+        buf.write('\n');
+      }
+    }
+
+    // Bottom border
+    buf.write('└');
+    for (var i = 0; i < colCount; i++) {
+      buf.write('─' * (colWidths[i] + 2));
+      buf.write(i < colCount - 1 ? '┴' : '┘');
+    }
+    buf.write('\n\n');
+
+    return [TextSpan(text: buf.toString())];
+  }
+
+  List<InlineSpan> _renderFootnoteDefinition(FootnoteDefinitionNode node) {
+    return [
+      TextSpan(
+        children: [
+          TextSpan(text: '[^${node.label}]: ', style: styleSheet.footnoteRefStyle),
+          ...renderNodes(node.children),
+          const TextSpan(text: '\n'),
+        ],
+      ),
+    ];
+  }
+
+  List<InlineSpan> _renderDetails(DetailsNode node) {
+    return [
+      TextSpan(
+        children: [
+          const TextSpan(
+            text: '▶ ',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          ...renderNodes(node.summary),
+          const TextSpan(text: '\n'),
+          if (node.isOpen) ...renderNodes(node.children),
+          const TextSpan(text: '\n'),
+        ],
+      ),
+    ];
+  }
+
+  String _plainText(List<MarkdownNode> nodes) {
+    final buf = StringBuffer();
+    for (final node in nodes) {
+      switch (node) {
+        case TextNode n:
+          buf.write(n.content);
+        case BoldNode n:
+          buf.write(_plainText(n.children));
+        case ItalicNode n:
+          buf.write(_plainText(n.children));
+        case InlineCodeNode n:
+          buf.write(n.code);
+        case LinkNode n:
+          buf.write(_plainText(n.children));
+        case HashtagNode n:
+          buf.write('#${n.tag}');
+        case MentionNode n:
+          buf.write('@${n.username}');
+        default:
+          break;
+      }
+    }
+    return buf.toString();
+  }
+}
+
+/// Block plugin that correctly parses nested ordered and unordered lists.
+///
+/// dart_markdown_parser flattens all indented list items to the same level.
+/// This plugin intercepts list blocks and builds proper nested [ListNode] trees
+/// by tracking indentation.
+class NestedListPlugin extends BlockParserPlugin {
+  const NestedListPlugin();
+
+  @override
+  String get id => 'nested_list';
+
+  @override
+  String get name => 'Nested List Plugin';
+
+  @override
+  int get priority => 100;
+
+  static final _orderedRe = RegExp(r'^(\s*)(\d+)\.\s+(.*)$');
+  static final _unorderedRe = RegExp(r'^(\s*)([-*+])\s+(.*)$');
+  static final _taskRe = RegExp(r'^\[([x ])\]\s+(.*)$', caseSensitive: false);
+
+  static Match? _matchItem(String line) => _orderedRe.firstMatch(line) ?? _unorderedRe.firstMatch(line);
+
+  @override
+  bool canParse(String line, List<String> lines, int index) => _matchItem(line) != null;
+
+  @override
+  BlockParseResult? parse(List<String> lines, int startIndex) {
+    final result = _parseList(lines, startIndex, _indentOf(lines[startIndex]));
+    return result;
+  }
+
+  BlockParseResult? _parseList(List<String> lines, int start, int baseIndent) {
+    final items = <ListItemNode>[];
+    bool? ordered;
+    int startIdx = 1;
+    int i = start;
+
+    while (i < lines.length) {
+      final line = lines[i];
+      if (line.trim().isEmpty) break;
+
+      final m = _matchItem(line);
+      if (m == null) break;
+
+      final indent = _indentOf(line);
+      if (indent != baseIndent) break;
+
+      final isOrdered = _orderedRe.hasMatch(line);
+      ordered ??= isOrdered;
+      if (ordered != isOrdered) break;
+      if (isOrdered && items.isEmpty) {
+        startIdx = int.parse(_orderedRe.firstMatch(line)!.group(2)!);
+      }
+
+      final rawContent = m.group(3)!;
+      final taskM = _taskRe.firstMatch(rawContent);
+      final checked = taskM != null ? taskM.group(1)!.toLowerCase() == 'x' : null;
+      final content = taskM != null ? taskM.group(2)! : rawContent;
+
+      i++;
+
+      // Collect sub-list if next line has greater indent
+      final children = <MarkdownNode>[TextNode(content)];
+      if (i < lines.length) {
+        final nextM = _matchItem(lines[i]);
+        if (nextM != null && _indentOf(lines[i]) > baseIndent) {
+          final sub = _parseList(lines, i, _indentOf(lines[i]));
+          if (sub != null) {
+            children.add(sub.node);
+            i += sub.linesConsumed;
+          }
+        }
+      }
+
+      items.add(ListItemNode(children: children, checked: checked));
+    }
+
+    if (items.isEmpty) return null;
+
+    return BlockParseResult(
+      node: ListNode(items: items, ordered: ordered ?? false, startIndex: startIdx),
+      linesConsumed: i - start,
+    );
+  }
+
+  int _indentOf(String line) {
+    int n = 0;
+    for (final ch in line.runes) {
+      if (ch == 0x20) {
+        n++; // space
+      } else if (ch == 0x09) {
+        n += 2; // tab counts as 2
+      } else {
+        break;
+      }
+    }
+    return n;
+  }
+}
+
+/// A component that renders Markdown content from dart_markdown_parser AST.
+class MDown extends StatefulComponent {
+  final String markdown;
+  final MDownStyleSheet styleSheet;
+  final List<ParserPlugin> plugins;
+
+  /// How the text should be aligned horizontally.
+  final TextAlign textAlign;
+
+  /// Whether the text should break at soft line breaks.
+  final bool softWrap;
+
+  /// How visual overflow should be handled.
+  final TextOverflow overflow;
+
+  /// An optional maximum number of lines for the text to span.
+  final int? maxLines;
+
+  const MDown(
+    this.markdown, {
+    super.key,
+    this.styleSheet = const MDownStyleSheet(),
+    this.plugins = const [],
+    this.textAlign = TextAlign.left,
+    this.softWrap = true,
+    this.overflow = TextOverflow.clip,
+    this.maxLines,
+  });
+
+  @override
+  State<MDown> createState() => _MDownState();
+}
+
+class _MDownState extends State<MDown> {
+  late final ParserPluginRegistry registry;
+  late List<MarkdownNode> nodes;
+  late List<InlineSpan> spans;
+
+  @override
+  void initState() {
+    super.initState();
+    registry = ParserPluginRegistry();
+    registry.register(const NestedListPlugin());
+    registry.register(const HashtagPlugin());
+    registry.register(const MentionPlugin());
+    for (final plugin in component.plugins) registry.register(plugin);
+
+    _parse();
+  }
+
+  @override
+  void didUpdateComponent(MDown oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (oldComponent.markdown != component.markdown) {
+      _parse();
+    }
+  }
+
+  // dart_markdown_parser doesn't handle ***text*** (bold+italic triple asterisk).
+  // It consumes ** for bold, leaving one dangling *. Normalize to **_text_** first.
+  static final _tripleAsterisk = RegExp(r'\*{3}(.+?)\*{3}', dotAll: true);
+
+  void _parse() {
+    final normalized = component.markdown.replaceAllMapped(_tripleAsterisk, (m) => '**_${m[1]}_**');
+    final parser = MarkdownParser(plugins: registry);
+    nodes = parser.parse(normalized);
+    final renderer = MDownRenderer(styleSheet: component.styleSheet);
+    spans = renderer.renderNodes(nodes);
+  }
+
+  @override
+  build(_) => RichText(
+        text: TextSpan(children: spans),
+        textAlign: component.textAlign,
+        softWrap: component.softWrap,
+        overflow: component.overflow,
+        maxLines: component.maxLines,
+      );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   hotreloader: ^4.2.0
   image: ^4.5.4
   markdown: ^7.2.0
+  dart_markdown_parser: ^0.1.1 
+  highlight: ^0.7.0
   path: ^1.9.0
 
   # TODO put this into a separate testing package

--- a/test/components/markdown_component_test.dart
+++ b/test/components/markdown_component_test.dart
@@ -1,0 +1,561 @@
+import 'package:dart_markdown_parser/dart_markdown_parser.dart';
+import 'package:nocterm/nocterm.dart';
+import 'package:nocterm/src/components/markdown_component.dart';
+import 'package:test/test.dart';
+
+/// Rich markdown example covering all supported features.
+const richMarkdown = '''
+# Main Title
+
+## Getting Started
+
+This is a paragraph with **bold text**, *italic text*, and ~~strikethrough~~.
+You can also combine ***bold and italic*** together.
+
+### Inline Elements
+
+Here is some `inline code` and a [link to Dart](https://dart.dev "Dart Language").
+Check out this image: ![Dart Logo](https://dart.dev/logo.png)
+
+#### Code Block
+
+```dart
+void main() {
+  print('Hello, World!');
+  final x = 42;
+}
+```
+
+##### Lists
+
+Unordered list:
+- First item
+- Second item with **bold**
+- Third item
+
+Ordered list:
+1. Step one
+2. Step two
+3. Step three
+
+Task list:
+- [x] Completed task
+- [ ] Pending task
+- [x] Another done
+
+###### Blockquote
+
+> This is a blockquote with *emphasis*.
+> It can span multiple lines.
+
+---
+
+| Language | Year | Creator    |
+|----------|------|------------|
+| Dart     | 2011 | Google     |
+| Rust     | 2010 | Mozilla    |
+| Go       | 2009 | Google     |
+
+We love the #flutter framework and ping @robbie for details!
+
+Here is a footnote reference[^1].
+
+[^1]: This is the footnote content.
+''';
+
+void main() {
+  group('MDownRenderer', () {
+    late MDownRenderer renderer;
+    late List<MarkdownNode> nodes;
+
+    setUp(() {
+      final registry = ParserPluginRegistry();
+      registry.register(const HashtagPlugin());
+      registry.register(const MentionPlugin());
+      final parser = MarkdownParser(plugins: registry);
+      nodes = parser.parse(richMarkdown);
+      renderer = MDownRenderer();
+    });
+
+    test('parses rich markdown into non-empty AST', () {
+      expect(nodes.length, greaterThan(5));
+    });
+
+    test('renders all nodes to spans without errors', () {
+      final spans = renderer.renderNodes(nodes);
+      expect(spans, isNotEmpty);
+    });
+
+    test('detects header nodes at multiple levels', () {
+      final headers = nodes.whereType<HeaderNode>().toList();
+      expect(headers.length, greaterThanOrEqualTo(6));
+
+      final levels = headers.map((h) => h.level).toSet();
+      expect(levels, contains(1));
+      expect(levels, contains(2));
+      expect(levels, contains(3));
+      expect(levels, contains(4));
+      expect(levels, contains(5));
+      expect(levels, contains(6));
+    });
+
+    test('renders headers with correct prefix', () {
+      final h1 = const HeaderNode(level: 1, content: 'Title', children: [TextNode('Title')]);
+      final text = _extractText(renderer.renderNode(h1));
+      expect(text, contains('# Title'));
+    });
+
+    test('renders h3 with ### prefix', () {
+      final h3 = const HeaderNode(level: 3, content: 'Sub', children: [TextNode('Sub')]);
+      final text = _extractText(renderer.renderNode(h3));
+      expect(text, contains('### Sub'));
+    });
+
+    test('detects paragraph nodes', () {
+      final paragraphs = nodes.whereType<ParagraphNode>().toList();
+      expect(paragraphs, isNotEmpty);
+    });
+
+    test('renders bold text with bold style', () {
+      final bold = const BoldNode([TextNode('strong')]);
+      final spans = renderer.renderNode(bold);
+      expect(spans, hasLength(1));
+      final ts = spans.first as TextSpan;
+      expect(ts.style!.fontWeight, equals(FontWeight.bold));
+    });
+
+    test('renders italic text with italic style', () {
+      final italic = const ItalicNode([TextNode('emphasis')]);
+      final spans = renderer.renderNode(italic);
+      final ts = spans.first as TextSpan;
+      expect(ts.style!.fontStyle, equals(FontStyle.italic));
+    });
+
+    test('renders strikethrough with lineThrough decoration', () {
+      final strike = const StrikethroughNode([TextNode('deleted')]);
+      final spans = renderer.renderNode(strike);
+      final ts = spans.first as TextSpan;
+      expect(ts.style!.decoration!.hasLineThrough, isTrue);
+    });
+
+    test('renders inline code with code style', () {
+      final code = const InlineCodeNode('var x = 1');
+      final spans = renderer.renderNode(code);
+      final ts = spans.first as TextSpan;
+      expect(ts.text, equals('var x = 1'));
+      expect(ts.style!.color, equals(Colors.yellow));
+      expect(ts.style!.backgroundColor, equals(Colors.black));
+    });
+
+    test('renders code block with language label', () {
+      final codeBlock = const CodeBlockNode(code: 'print("hi")', language: 'dart');
+      final text = _extractText(renderer.renderNode(codeBlock));
+      expect(text, contains('dart'));
+      expect(text, contains('print("hi")'));
+    });
+
+    test('renders code block without language', () {
+      final codeBlock = const CodeBlockNode(code: 'raw code');
+      final text = _extractText(renderer.renderNode(codeBlock));
+      expect(text, contains('raw code'));
+    });
+
+    test('renders link with URL in brackets', () {
+      final link = const LinkNode(url: 'https://dart.dev', children: [TextNode('Dart')]);
+      final text = _extractText(renderer.renderNode(link));
+      expect(text, contains('Dart'));
+      expect(text, contains('[https://dart.dev]'));
+    });
+
+    test('renders image as alt text', () {
+      final img = const ImageNode(url: 'https://img.png', alt: 'logo');
+      final text = _extractText(renderer.renderNode(img));
+      expect(text, contains('[Image: logo]'));
+    });
+
+    test('detects unordered list', () {
+      final lists = nodes.whereType<ListNode>().where((l) => !l.ordered).toList();
+      expect(lists, isNotEmpty);
+    });
+
+    test('detects ordered list', () {
+      final lists = nodes.whereType<ListNode>().where((l) => l.ordered).toList();
+      expect(lists, isNotEmpty);
+    });
+
+    test('renders unordered list items with bullet', () {
+      final list = ListNode(
+        items: [
+          const ListItemNode(children: [TextNode('item')]),
+        ],
+      );
+      final text = _extractText(renderer.renderNode(list));
+      expect(text, contains('• item'));
+    });
+
+    test('renders ordered list items with index', () {
+      final list = ListNode(
+        ordered: true,
+        items: [
+          const ListItemNode(children: [TextNode('first')]),
+          const ListItemNode(children: [TextNode('second')]),
+        ],
+      );
+      final text = _extractText(renderer.renderNode(list));
+      expect(text, contains('1. first'));
+      expect(text, contains('2. second'));
+    });
+
+    test('renders task list with checkboxes', () {
+      final list = ListNode(
+        items: [
+          const ListItemNode(children: [TextNode('done')], checked: true),
+          const ListItemNode(children: [TextNode('todo')], checked: false),
+        ],
+      );
+      final text = _extractText(renderer.renderNode(list));
+      expect(text, contains('◉ done'));
+      expect(text, contains('◎ todo'));
+    });
+
+    test('renders blockquote with pipe prefix', () {
+      final bq = const BlockquoteNode([
+        ParagraphNode([TextNode('quoted')]),
+      ]);
+      final text = _extractText(renderer.renderNode(bq));
+      expect(text, contains('│ '));
+      expect(text, contains('quoted'));
+    });
+
+    test('renders multiline blockquote with pipe on every line', () {
+      final bq = const BlockquoteNode([
+        ParagraphNode([TextNode('line one.\nline two.')]),
+      ]);
+      final text = _extractText(renderer.renderNode(bq));
+      expect(text, contains('│ line one.\n│ line two.'));
+    });
+
+    test('renders horizontal rule', () {
+      final text = _extractText(renderer.renderNode(const HorizontalRuleNode()));
+      expect(text, contains('─' * 40));
+    });
+
+    test('detects table node', () {
+      final tables = nodes.whereType<TableNode>().toList();
+      expect(tables, isNotEmpty);
+    });
+
+    test('renders table with borders', () {
+      final table = TableNode(
+        headers: [
+          [const TextNode('Name')],
+          [const TextNode('Age')],
+        ],
+        alignments: [null, null],
+        rows: [
+          const TableRowNode([
+            [TextNode('Alice')],
+            [TextNode('30')],
+          ]),
+        ],
+      );
+      final text = _extractText(renderer.renderNode(table));
+      expect(text, contains('┌'));
+      expect(text, contains('┐'));
+      expect(text, contains('├'));
+      expect(text, contains('┤'));
+      expect(text, contains('└'));
+      expect(text, contains('┘'));
+      expect(text, contains('Name'));
+      expect(text, contains('Alice'));
+    });
+
+    test('nested ordered list renders correct sub-item indices', () {
+      final registry = ParserPluginRegistry();
+      registry.register(const NestedListPlugin());
+      final parser = MarkdownParser(plugins: registry);
+      final nodes = parser.parse(
+        '1. première\n2. deuxième\n   1. sous-étape a\n   2. sous-étape b\n3. troisième\n',
+      );
+
+      expect(nodes, hasLength(1));
+      final list = nodes.first as ListNode;
+      expect(list.items, hasLength(3));
+
+      final second = list.items[1];
+      final subList = second.children.whereType<ListNode>().first;
+      expect(subList.startIndex, equals(1));
+      expect(subList.items, hasLength(2));
+
+      final spans = renderer.renderNodes(nodes);
+      final text = _extractText(spans);
+      expect(text, contains('1. sous-étape a'));
+      expect(text, contains('2. sous-étape b'));
+      expect(text, contains('3. troisième'));
+      expect(text, isNot(contains('3. sous-étape')));
+      expect(text, isNot(contains('4. sous-étape')));
+    });
+
+    test('nested unordered list renders correct sub-bullets', () {
+      final registry = ParserPluginRegistry();
+      registry.register(const NestedListPlugin());
+      final parser = MarkdownParser(plugins: registry);
+      final nodes = parser.parse('- parent\n  - child a\n  - child b\n- other\n');
+
+      final list = nodes.first as ListNode;
+      expect(list.items, hasLength(2));
+      final sub = list.items[0].children.whereType<ListNode>().first;
+      expect(sub.items, hasLength(2));
+    });
+
+    test('renders diff code block with line colors', () {
+      const diffCode = CodeBlockNode(
+        language: 'diff',
+        code: '+ ligne ajoutée\n- ligne supprimée\n! ligne importante\n# commentaire neutre\n  context line',
+      );
+      final spans = renderer.renderNode(diffCode);
+      final allSpans = _flattenSpans(spans);
+
+      final addSpan = allSpans.firstWhere((s) => s.text?.startsWith('+') ?? false);
+      expect(addSpan.style!.color, equals(Colors.green));
+
+      final delSpan = allSpans.firstWhere((s) => s.text?.startsWith('-') ?? false);
+      expect(delSpan.style!.color, equals(Colors.red));
+
+      final impSpan = allSpans.firstWhere((s) => s.text?.startsWith('!') ?? false);
+      expect(impSpan.style!.color, equals(Colors.yellow));
+
+      final cmtSpan = allSpans.firstWhere((s) => s.text?.startsWith('#') ?? false);
+      expect(cmtSpan.style!.color, equals(Colors.grey));
+    });
+
+    test('renders git language as diff', () {
+      const gitBlock = CodeBlockNode(language: 'git', code: '+ added\n- removed');
+      final spans = renderer.renderNode(gitBlock);
+      final allSpans = _flattenSpans(spans);
+      final addSpan = allSpans.firstWhere((s) => s.text?.startsWith('+') ?? false);
+      expect(addSpan.style!.color, equals(Colors.green));
+    });
+
+    test('renders inline math', () {
+      final math = const InlineMathNode('E=mc^2');
+      final text = _extractText(renderer.renderNode(math));
+      expect(text, contains(r'$E=mc^2$'));
+    });
+
+    test('renders block math', () {
+      final math = const BlockMathNode(r'\sum x_i');
+      final text = _extractText(renderer.renderNode(math));
+      expect(text, contains(r'$$\sum x_i$$'));
+    });
+
+    test('renders footnote reference', () {
+      final ref = const FootnoteReferenceNode('1');
+      final text = _extractText(renderer.renderNode(ref));
+      expect(text, contains('[^1]'));
+    });
+
+    test('renders footnote definition', () {
+      final def = const FootnoteDefinitionNode(label: '1', children: [TextNode('Footnote content')]);
+      final text = _extractText(renderer.renderNode(def));
+      expect(text, contains('[^1]: '));
+      expect(text, contains('Footnote content'));
+    });
+
+    test('renders hashtag with # and magenta style', () {
+      final tag = const HashtagNode('flutter');
+      final spans = renderer.renderNode(tag);
+      final ts = spans.first as TextSpan;
+      expect(ts.text, equals('#flutter'));
+      expect(ts.style!.color, equals(Colors.magenta));
+    });
+
+    test('renders mention with @ and cyan style', () {
+      final mention = const MentionNode('robbie');
+      final spans = renderer.renderNode(mention);
+      final ts = spans.first as TextSpan;
+      expect(ts.text, equals('@robbie'));
+      expect(ts.style!.color, equals(Colors.cyan));
+    });
+
+    test('detects hashtag and mention in parsed AST', () {
+      bool hasHashtag = false;
+      bool hasMention = false;
+      _walkNodes(nodes, (node) {
+        if (node is HashtagNode && node.tag == 'flutter') hasHashtag = true;
+        if (node is MentionNode && node.username == 'robbie') hasMention = true;
+      });
+      expect(hasHashtag, isTrue);
+      expect(hasMention, isTrue);
+    });
+
+    test('renders details node with open content', () {
+      final details = const DetailsNode(
+        summary: [TextNode('Click me')],
+        children: [
+          ParagraphNode([TextNode('Hidden')]),
+        ],
+        isOpen: true,
+      );
+      final text = _extractText(renderer.renderNode(details));
+      expect(text, contains('▶ Click me'));
+      expect(text, contains('Hidden'));
+    });
+
+    test('renders details node collapsed hides content', () {
+      final details = const DetailsNode(
+        summary: [TextNode('Collapsed')],
+        children: [
+          ParagraphNode([TextNode('Secret')]),
+        ],
+        isOpen: false,
+      );
+      final text = _extractText(renderer.renderNode(details));
+      expect(text, contains('Collapsed'));
+      expect(text, isNot(contains('Secret')));
+    });
+
+    test('full rich markdown renders to non-trivial span tree', () {
+      final spans = renderer.renderNodes(nodes);
+      final fullText = _extractText(spans);
+
+      expect(fullText, contains('Main Title'));
+      expect(fullText, contains('Getting Started'));
+      expect(fullText, contains('inline code'));
+      expect(fullText, contains('Hello, World!'));
+      expect(fullText, contains('@robbie'));
+      expect(fullText, contains('Dart'));
+      expect(fullText, contains('─' * 40));
+    });
+
+    test('renders bold+italic nesting (BoldNode > ItalicNode)', () {
+      // ***text*** is normalized to **_text_** before parsing, producing this AST
+      final boldItalic = const BoldNode([
+        ItalicNode([TextNode('combined')])
+      ]);
+      final spans = renderer.renderNode(boldItalic);
+      final outer = spans.first as TextSpan;
+      expect(outer.style!.fontWeight, equals(FontWeight.bold));
+      final inner = outer.children!.first as TextSpan;
+      expect(inner.style!.fontStyle, equals(FontStyle.italic));
+    });
+
+    test('custom stylesheet is applied', () {
+      final custom = MDownStyleSheet(
+        h1Style: const TextStyle(color: Colors.red),
+        boldStyle: const TextStyle(fontWeight: FontWeight.bold, color: Colors.green),
+      );
+      final r = MDownRenderer(styleSheet: custom);
+      final h1 = const HeaderNode(level: 1, content: 'Test', children: [TextNode('Test')]);
+      final spans = r.renderNode(h1);
+      final ts = spans.first as TextSpan;
+      expect(ts.style!.color, equals(Colors.red));
+    });
+  });
+
+  group('MDown component', () {
+    test('creates with required markdown', () {
+      final mdown = MDown('# Hello');
+      expect(mdown.markdown, equals('# Hello'));
+    });
+
+    test('accepts custom stylesheet', () {
+      final sheet = MDownStyleSheet(h1Style: const TextStyle(color: Colors.red));
+      final mdown = MDown('# Test', styleSheet: sheet);
+      expect(mdown.styleSheet.h1Style.color, equals(Colors.red));
+    });
+
+    test('accepts custom plugins', () {
+      final mdown = MDown('test', plugins: [const EmojiPlugin()]);
+      expect(mdown.plugins, hasLength(1));
+    });
+  });
+
+  group('MDownStyleSheet', () {
+    test('default styles are set', () {
+      const sheet = MDownStyleSheet();
+      expect(sheet.h1Style.color, equals(Colors.cyan));
+      expect(sheet.h2Style.color, equals(Colors.blue));
+      expect(sheet.h3Style.color, equals(Colors.green));
+      expect(sheet.boldStyle.fontWeight, equals(FontWeight.bold));
+      expect(sheet.italicStyle.fontStyle, equals(FontStyle.italic));
+      expect(sheet.listBullet, equals('• '));
+    });
+
+    test('headerStyle returns correct style for each level', () {
+      const sheet = MDownStyleSheet();
+      expect(sheet.headerStyle(1).color, equals(Colors.cyan));
+      expect(sheet.headerStyle(2).color, equals(Colors.blue));
+      expect(sheet.headerStyle(3).color, equals(Colors.green));
+      expect(sheet.headerStyle(6).fontStyle, equals(FontStyle.italic));
+    });
+  });
+}
+
+/// Flattens a span tree into a flat list of leaf TextSpans (those with text).
+List<TextSpan> _flattenSpans(List<InlineSpan> spans) {
+  final result = <TextSpan>[];
+  void visit(InlineSpan span) {
+    if (span is TextSpan) {
+      if (span.text != null) result.add(span);
+      span.children?.forEach(visit);
+    }
+  }
+
+  spans.forEach(visit);
+  return result;
+}
+
+/// Recursively extracts all plain text from a list of InlineSpan.
+String _extractText(List<InlineSpan> spans) {
+  final buf = StringBuffer();
+  for (final span in spans) {
+    _collectText(span, buf);
+  }
+  return buf.toString();
+}
+
+void _collectText(InlineSpan span, StringBuffer buf) {
+  if (span is TextSpan) {
+    if (span.text != null) buf.write(span.text);
+    if (span.children != null) {
+      for (final child in span.children!) {
+        _collectText(child, buf);
+      }
+    }
+  }
+}
+
+/// Walks all nodes recursively, calling [visitor] on each.
+void _walkNodes(List<MarkdownNode> nodes, void Function(MarkdownNode) visitor) {
+  for (final node in nodes) {
+    visitor(node);
+    switch (node) {
+      case ParagraphNode n:
+        _walkNodes(n.children, visitor);
+      case HeaderNode n:
+        if (n.children != null) _walkNodes(n.children!, visitor);
+      case BoldNode n:
+        _walkNodes(n.children, visitor);
+      case ItalicNode n:
+        _walkNodes(n.children, visitor);
+      case StrikethroughNode n:
+        _walkNodes(n.children, visitor);
+      case LinkNode n:
+        _walkNodes(n.children, visitor);
+      case ListNode n:
+        _walkNodes(n.items, visitor);
+      case ListItemNode n:
+        _walkNodes(n.children, visitor);
+      case BlockquoteNode n:
+        _walkNodes(n.children, visitor);
+      case FootnoteDefinitionNode n:
+        _walkNodes(n.children, visitor);
+      case DetailsNode n:
+        _walkNodes(n.summary, visitor);
+        _walkNodes(n.children, visitor);
+      default:
+        break;
+    }
+  }
+}


### PR DESCRIPTION
dart_markdown_parser from @JackCaow at the core.

This is an early review

Support many new tags and features like code colors and plugins

Find some part that may leave the Component and moved back to the original Dart lib
https://github.com/JackCaow/dart_markdown_parser/issues/1

Support added for code syntax coloration and others tags.