### PR TITLE
fix: handle all modifier combinations and Home/End in modified key parsing

### DIFF
--- a/lib/src/keyboard/input_parser.dart
+++ b/lib/src/keyboard/input_parser.dart
@@ -419,117 +419,27 @@ class InputParser {
     if (_buffer.length >= 6) {
       final sequence = String.fromCharCodes(_buffer);
 
-      // Shift+Arrow: ESC [ 1 ; 2 A/B/C/D
-      if (sequence.startsWith('\x1B[1;2')) {
-        switch (_buffer[5]) {
-          case 0x41:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowUp,
-                modifiers: const ModifierKeys(shift: true),
-              ),
-              6
-            );
-          case 0x42:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowDown,
-                modifiers: const ModifierKeys(shift: true),
-              ),
-              6
-            );
-          case 0x43:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowRight,
-                modifiers: const ModifierKeys(shift: true),
-              ),
-              6
-            );
-          case 0x44:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowLeft,
-                modifiers: const ModifierKeys(shift: true),
-              ),
-              6
-            );
-        }
-      }
-
-      // Alt+Arrow: ESC [ 1 ; 3 A/B/C/D
-      if (sequence.startsWith('\x1B[1;3')) {
-        switch (_buffer[5]) {
-          case 0x41:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowUp,
-                modifiers: const ModifierKeys(alt: true),
-              ),
-              6
-            );
-          case 0x42:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowDown,
-                modifiers: const ModifierKeys(alt: true),
-              ),
-              6
-            );
-          case 0x43:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowRight,
-                modifiers: const ModifierKeys(alt: true),
-              ),
-              6
-            );
-          case 0x44:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowLeft,
-                modifiers: const ModifierKeys(alt: true),
-              ),
-              6
-            );
-        }
-      }
-
-      // Ctrl+Arrow: ESC [ 1 ; 5 A/B/C/D
-      if (sequence.startsWith('\x1B[1;5')) {
-        switch (_buffer[5]) {
-          case 0x41:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowUp,
-                modifiers: const ModifierKeys(ctrl: true),
-              ),
-              6
-            );
-          case 0x42:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowDown,
-                modifiers: const ModifierKeys(ctrl: true),
-              ),
-              6
-            );
-          case 0x43:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowRight,
-                modifiers: const ModifierKeys(ctrl: true),
-              ),
-              6
-            );
-          case 0x44:
-            return (
-              KeyboardEvent(
-                logicalKey: LogicalKey.arrowLeft,
-                modifiers: const ModifierKeys(ctrl: true),
-              ),
-              6
-            );
+      // Modified arrow/home/end keys: ESC [ 1 ; {modifier} A/B/C/D/H/F
+      // Modifier is 1 + bitmask (shift=1, alt=2, ctrl=4, meta=8).
+      // Handles all combinations: Shift(2), Alt(3), Alt+Shift(4), Ctrl(5),
+      // Ctrl+Shift(6), Ctrl+Alt(7), Ctrl+Alt+Shift(8), etc.
+      if (sequence.startsWith('\x1B[1;') && _buffer.length == 6) {
+        final modValue = int.tryParse(String.fromCharCode(_buffer[4]));
+        if (modValue != null) {
+          final modifiers = _decodeModifiers(modValue);
+          final LogicalKey? key;
+          switch (_buffer[5]) {
+            case 0x41: key = LogicalKey.arrowUp;
+            case 0x42: key = LogicalKey.arrowDown;
+            case 0x43: key = LogicalKey.arrowRight;
+            case 0x44: key = LogicalKey.arrowLeft;
+            case 0x48: key = LogicalKey.home;
+            case 0x46: key = LogicalKey.end;
+            default: key = null;
+          }
+          if (key != null) {
+            return (KeyboardEvent(logicalKey: key, modifiers: modifiers), 6);
+          }
         }
       }
     }

--- a/lib/src/keyboard/keyboard_parser.dart
+++ b/lib/src/keyboard/keyboard_parser.dart
@@ -254,81 +254,27 @@ class KeyboardParser {
     if (_buffer.length >= 6) {
       final sequence = String.fromCharCodes(_buffer);
 
-      // Shift+Arrow: ESC [ 1 ; 2 A/B/C/D
-      if (sequence.startsWith('\x1B[1;2')) {
-        switch (_buffer[5]) {
-          case 0x41:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowUp,
-              modifiers: const ModifierKeys(shift: true),
-            );
-          case 0x42:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowDown,
-              modifiers: const ModifierKeys(shift: true),
-            );
-          case 0x43:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowRight,
-              modifiers: const ModifierKeys(shift: true),
-            );
-          case 0x44:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowLeft,
-              modifiers: const ModifierKeys(shift: true),
-            );
-        }
-      }
-
-      // Alt+Arrow: ESC [ 1 ; 3 A/B/C/D
-      if (sequence.startsWith('\x1B[1;3')) {
-        switch (_buffer[5]) {
-          case 0x41:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowUp,
-              modifiers: const ModifierKeys(alt: true),
-            );
-          case 0x42:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowDown,
-              modifiers: const ModifierKeys(alt: true),
-            );
-          case 0x43:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowRight,
-              modifiers: const ModifierKeys(alt: true),
-            );
-          case 0x44:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowLeft,
-              modifiers: const ModifierKeys(alt: true),
-            );
-        }
-      }
-
-      // Ctrl+Arrow: ESC [ 1 ; 5 A/B/C/D
-      if (sequence.startsWith('\x1B[1;5')) {
-        switch (_buffer[5]) {
-          case 0x41:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowUp,
-              modifiers: const ModifierKeys(ctrl: true),
-            );
-          case 0x42:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowDown,
-              modifiers: const ModifierKeys(ctrl: true),
-            );
-          case 0x43:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowRight,
-              modifiers: const ModifierKeys(ctrl: true),
-            );
-          case 0x44:
-            return KeyboardEvent(
-              logicalKey: LogicalKey.arrowLeft,
-              modifiers: const ModifierKeys(ctrl: true),
-            );
+      // Modified arrow/home/end keys: ESC [ 1 ; {modifier} A/B/C/D/H/F
+      // Modifier is 1 + bitmask (shift=1, alt=2, ctrl=4, meta=8).
+      // Handles all combinations: Shift(2), Alt(3), Alt+Shift(4), Ctrl(5),
+      // Ctrl+Shift(6), Ctrl+Alt(7), Ctrl+Alt+Shift(8), etc.
+      if (sequence.startsWith('\x1B[1;') && _buffer.length == 6) {
+        final modValue = int.tryParse(String.fromCharCode(_buffer[4]));
+        if (modValue != null) {
+          final modifiers = _decodeModifiers(modValue);
+          final LogicalKey? key;
+          switch (_buffer[5]) {
+            case 0x41: key = LogicalKey.arrowUp;
+            case 0x42: key = LogicalKey.arrowDown;
+            case 0x43: key = LogicalKey.arrowRight;
+            case 0x44: key = LogicalKey.arrowLeft;
+            case 0x48: key = LogicalKey.home;
+            case 0x46: key = LogicalKey.end;
+            default: key = null;
+          }
+          if (key != null) {
+            return KeyboardEvent(logicalKey: key, modifiers: modifiers);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- The xterm modified key parser (`ESC[1;{mod}X`) only handled Shift(2), Alt(3), and Ctrl(5) with arrow keys
- Modifier combinations (Ctrl+Shift, Ctrl+Alt, Alt+Shift, etc.) and modified Home/End keys were silently consumed as unrecognized sequences
- Reuses the existing `_decodeModifiers` bitmask decoder to handle all modifier values, and adds Home (`0x48`) and End (`0x46`) to the key map
- Applied to both `InputParser` and `KeyboardParser`
- Net -144 lines by collapsing three nearly-identical switch blocks into one generic handler

## Test plan
- [x] All 1253 existing tests pass
- [x] `dart analyze` clean on both modified files
- [x] Manual verification of Shift+Home, Ctrl+End, Ctrl+Shift+Arrow in a terminal app

🤖 Generated with [Claude Code](https://claude.com/claude-code)