### PR TITLE
fix: Use InputDecoration instead BoxDecoration in example

### DIFF
--- a/docs-site/content/docs/components/input.mdx
+++ b/docs-site/content/docs/components/input.mdx
@@ -31,7 +31,7 @@ class _MyFormState extends State<MyForm> {
   Component build(BuildContext context) {
     return TextField(
       controller: _controller,
-      decoration: BoxDecoration(
+      decoration: InputDecoration(
         border: BoxBorder.all(color: Colors.gray),
       ),
     );


### PR DESCRIPTION
Just a little fix in the examples.

`TextField` decoration requires `InputDecoration` not `BoxDecoration`.