### PR TITLE
refactor: use equality not identity

### DIFF
--- a/lib/src/components/list_view.dart
+++ b/lib/src/components/list_view.dart
@@ -544,6 +544,10 @@ class RenderListViewport extends RenderObject with ScrollableRenderObjectMixin {
         _selectionRangeFor = selectionRangeFor {
     _controller.addListener(_handleScrollUpdate);
     _controller.attach(this);
+    // Selection drag state is a global, so we subscribe explicitly -
+    // changes there affect whether performLayout force-builds the selection
+    // range but wouldn't otherwise propagate through the normal dirty path.
+    SelectionDragState.addListener(markNeedsLayout);
   }
 
   _ListViewportElement? _element;
@@ -703,6 +707,7 @@ class RenderListViewport extends RenderObject with ScrollableRenderObjectMixin {
   void dispose() {
     _controller.removeListener(_handleScrollUpdate);
     _controller.detach(this);
+    SelectionDragState.removeListener(markNeedsLayout);
     super.dispose();
   }
 

--- a/lib/src/components/list_view.dart
+++ b/lib/src/components/list_view.dart
@@ -346,10 +346,13 @@ class _ListViewportElement extends RenderObjectElement {
 
   @override
   void update(Component newComponent) {
+    final oldViewport = component;
     super.update(newComponent);
 
-    // Remove cached children that are beyond the new item count
-    final newItemCount = (newComponent as _ListViewport).itemCount;
+    final newViewport = newComponent as _ListViewport;
+
+    // Remove cached children that are beyond the new item count.
+    final newItemCount = newViewport.itemCount;
     if (newItemCount != null) {
       _children.removeWhere((index, _) => index >= 0 && index >= newItemCount);
     }
@@ -358,11 +361,13 @@ class _ListViewportElement extends RenderObjectElement {
     // This is necessary when parent state changes (e.g., selection index)
     _needsChildUpdate = true;
     _updatedThisLayout.clear();
-    // NOTE: We do NOT call markNeedsLayout() here because:
-    // 1. If layout is needed, it will be triggered by constraint changes
-    // 2. Calling it unconditionally causes infinite frame loops when parent
-    //    rebuilds frequently (e.g., due to ValueListenableBuilder)
-    // 3. The _needsChildUpdate flag ensures children get updated on next layout
+
+    final layoutAffectingChanged = oldViewport.itemCount != newItemCount ||
+        !identical(oldViewport.itemBuilder, newViewport.itemBuilder) ||
+        !identical(oldViewport.separatorBuilder, newViewport.separatorBuilder);
+    if (layoutAffectingChanged) {
+      renderObject.markNeedsLayout();
+    }
   }
 
   /// Called by RenderListViewport after layout completes to reset update flags.

--- a/lib/src/components/selection_state.dart
+++ b/lib/src/components/selection_state.dart
@@ -1,14 +1,35 @@
 /// Global selection drag state used to coordinate behavior across widgets.
+///
+/// Render objects that depend on this (fx. [RenderListViewport])
+/// register callbacks via [addListener] and mark themselves dirty.
 class SelectionDragState {
   static int _activeCount = 0;
   static final Map<Object, SelectionRange> _ranges = {};
+  static final Set<void Function()> _listeners = {};
 
   /// Whether a selection drag is currently active.
   static bool get isActive => _activeCount > 0;
 
+  static void addListener(void Function() listener) {
+    _listeners.add(listener);
+  }
+
+  static void removeListener(void Function() listener) {
+    _listeners.remove(listener);
+  }
+
+  static void _notify() {
+    if (_listeners.isEmpty) return;
+    // Snapshot so listeners can safely detach themselves mid-iteration.
+    for (final listener in _listeners.toList(growable: false)) {
+      listener();
+    }
+  }
+
   /// Mark selection drag as active.
   static void begin() {
     _activeCount++;
+    _notify();
   }
 
   /// Mark selection drag as inactive.
@@ -19,11 +40,16 @@ class SelectionDragState {
     if (_activeCount == 0) {
       _ranges.clear();
     }
+    _notify();
   }
 
   static void updateRange(Object context, int minIndex, int maxIndex) {
     if (minIndex > maxIndex) return;
-    _ranges[context] = SelectionRange(minIndex, maxIndex);
+    final newRange = SelectionRange(minIndex, maxIndex);
+    final existing = _ranges[context];
+    if (existing == newRange) return;
+    _ranges[context] = newRange;
+    _notify();
   }
 
   static SelectionRange? rangeFor(Object context) {
@@ -32,8 +58,18 @@ class SelectionDragState {
 }
 
 class SelectionRange {
-  SelectionRange(this.minIndex, this.maxIndex);
+  const SelectionRange(this.minIndex, this.maxIndex);
 
   final int minIndex;
   final int maxIndex;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SelectionRange &&
+          other.minIndex == minIndex &&
+          other.maxIndex == maxIndex);
+
+  @override
+  int get hashCode => Object.hash(minIndex, maxIndex);
 }

--- a/lib/src/framework/layout_builder.dart
+++ b/lib/src/framework/layout_builder.dart
@@ -72,14 +72,14 @@ class LayoutBuilderElement extends RenderObjectElement {
 
   @override
   void update(Component newComponent) {
+    final oldBuilder = component.builder;
     super.update(newComponent);
-    // Mark that we need to rebuild with the new builder function.
-    // We DON'T call markNeedsLayout() here because:
-    // 1. If constraints change, layout will be triggered by the parent anyway
-    // 2. If only the builder changed, we'll use it next time layout runs
-    // 3. Calling markNeedsLayout unconditionally causes infinite frame loops
-    //    when the parent rebuilds frequently (e.g., due to ValueListenableBuilder)
     _needsBuild = true;
+    // A fresh builder closure captures whatever state the parent saw this build pass.
+    // Hence identity compare is a cheap proxy for "captured state may differ".
+    if (!identical(oldBuilder, component.builder)) {
+      renderObject.markNeedsLayout();
+    }
   }
 
   @override

--- a/lib/src/framework/proxy_element.dart
+++ b/lib/src/framework/proxy_element.dart
@@ -98,8 +98,9 @@ class ParentDataElement<T extends ParentData> extends ProxyElement {
           }
         }
 
-        // Default: Apply parent data to the render object
+        // May impact parent layout (FlexParentData.flex, etc.)
         renderObject.parentData = newData;
+        renderObject.parent?.markNeedsLayout();
       } else {
         // Recursively apply to children if this isn't a render object element
         child.visitChildren(applyParentDataToChild);

--- a/lib/src/framework/render_object.dart
+++ b/lib/src/framework/render_object.dart
@@ -376,19 +376,14 @@ abstract class RenderObject {
     _lastError = null;
     _lastStackTrace = null;
 
-    // We can skip layout if:
-    // 1. This render object doesn't need layout (_needsLayout is false)
-    // 2. The constraints are IDENTICAL (same object instance, not just equal values)
-    //
-    // Note: We intentionally use `identical()` instead of `==` here.
-    // Using value equality (==) was causing layout bugs in complex component trees
-    // (e.g., vide_cli's tool renderers) where children would skip relayout when
-    // their content changed but constraints remained the same by value.
-    // The identical() check is more conservative and only skips when we're truly
-    // being called with the exact same constraints object.
-    if (!_needsLayout && identical(constraints, _constraints)) return;
+    // Skip layout when we're not dirty and constraints haven't changed.
+    // Elements that mutate layout-relevant state (LayoutBuilder's builder,
+    // ListView's itemBuilder, ParentDataElement's parentData, etc.) must
+    // call markNeedsLayout explicitly - do NOT swap this back to
+    // `identical()` to compensate for a missing mark elsewhere.
+    if (!_needsLayout && constraints == _constraints) return;
 
-    final constraintsChanged = !identical(constraints, _constraints);
+    final constraintsChanged = constraints != _constraints;
     _constraints = constraints;
     if (_needsLayout || _size == null || constraintsChanged) {
       // Set _needsLayout = false BEFORE calling performLayout so that

--- a/lib/src/framework/render_object.dart
+++ b/lib/src/framework/render_object.dart
@@ -300,8 +300,11 @@ abstract class RenderObject {
     _size = value;
   }
 
-  bool _needsLayout = true;
-  bool _needsPaint = true;
+  // Flags start false so the first mark still apply in markNeedsLayout / markNeedsPaint.
+  // Initial layout/paint is still guaranteed because `layout()` falls through when `_size == null`,
+  // and `paintWithContext` forces a paint when `_cachedBuffer == null`.
+  bool _needsLayout = false;
+  bool _needsPaint = false;
   bool _hasLayoutError = false;
 
   /// Whether this render object needs layout.
@@ -323,11 +326,15 @@ abstract class RenderObject {
   /// Mark this render object as needing layout.
   ///
   /// This will cause [performLayout] to be called during the next layout pass.
-  /// The layout mark is propagated up the tree to ensure ancestors also re-layout.
+  /// The mark propagates up the tree the first time it's set; subsequent calls short-circuit.
+  //
+  /// Frame-skip in the scheduler can retire `_hasScheduledFrame` between calls,
+  /// so we always need to prod the owner.
   void markNeedsLayout() {
-    // Always set the flag and call markNeedsPaint() to ensure requestVisualUpdate()
-    // is called, even if the flag was already set. This prevents rendering from
-    // permanently stopping when the frame-skip optimization is active.
+    if (_needsLayout) {
+      owner?.requestVisualUpdate();
+      return;
+    }
     _needsLayout = true;
     markNeedsPaint();
     parent?.markNeedsLayout();
@@ -336,11 +343,14 @@ abstract class RenderObject {
   /// Mark this render object as needing to be repainted.
   ///
   /// This will cause [paint] to be called during the next paint pass.
-  /// The paint request will propagate up to the root, which will trigger
-  /// a frame to be scheduled.
+  /// The paint request will propagate up to the nearest repaint boundary on first mark.
+  /// Subsequent calls while already dirty short-circuit after re-requesting a visual update
+  /// (same frame-skip concern as [markNeedsLayout]).
   void markNeedsPaint() {
-    // Always set the flag (don't early return if already dirty)
-    // We still need to propagate to ensure requestVisualUpdate() is called
+    if (_needsPaint) {
+      owner?.requestVisualUpdate();
+      return;
+    }
     _needsPaint = true;
 
     if (parent != null) {

--- a/test/components/list_view_row_layout_regression_test.dart
+++ b/test/components/list_view_row_layout_regression_test.dart
@@ -1,0 +1,121 @@
+// Regression test for the ListView child-constraints caching mishap.
+//
+// Symptom observed in serverpod_cli's start-command log viewer: after the
+// ListView cached its childConstraints across frames, the first few columns
+// of Row-based list items (type label, timestamp) would drop out, leaving
+// only the Expanded(Divider)/Expanded(Text) filling the row. The cached
+// constraints object made RenderObject.layout's `identical(constraints,
+// _constraints)` short-circuit trigger on the row, so RenderFlex.performLayout
+// never re-ran and the row's children kept whatever offsets and sizes they
+// had from a transient earlier frame.
+//
+// The pattern mirrors serverpod's LogMessageWidget / CompletedOperationWidget:
+// a Row with a few fixed-width Text/SizedBox leaders followed by an
+// Expanded child. If the Row's own layout is skipped, all the fixed-width
+// leaders collapse to the default parent-data offset (0, 0) and the
+// Expanded gets the whole row - exactly the visual breakage observed.
+
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'ListView Row items keep their leading columns across rebuilds',
+    () async {
+      await testNocterm('row leaders preserved across rebuild', (tester) async {
+        await tester.pumpComponent(_LogViewer());
+
+        final stateFinder = tester.findState<_LogViewerState>();
+        expect(
+          tester.terminalState.containsText('info'),
+          isTrue,
+          reason: 'initial frame must show the level label column',
+        );
+        expect(
+          tester.terminalState.containsText('boot'),
+          isTrue,
+          reason: 'initial frame must show the message column',
+        );
+
+        // Append more entries. This is exactly the serverpod scenario: the
+        // ListView's parent rebuilds with a larger itemCount, and existing
+        // items get re-reconciled while new ones are built fresh.
+        stateFinder.appendEntry('info', 'one');
+        await tester.pump();
+        stateFinder.appendEntry('warn', 'two');
+        await tester.pump();
+        stateFinder.appendEntry('error', 'three');
+        await tester.pump();
+
+        // Every message column must still be visible. If the row's layout was
+        // short-circuited, the Expanded(Text(message)) slid to column 0 and
+        // painted over the label, so the label text would disappear even
+        // though the underlying entry still exists.
+        for (final level in const ['info', 'warn', 'error']) {
+          expect(
+            tester.terminalState.containsText(level),
+            isTrue,
+            reason: 'level column "$level" disappeared after rebuild',
+          );
+        }
+        for (final msg in const ['boot', 'one', 'two', 'three']) {
+          expect(
+            tester.terminalState.containsText(msg),
+            isTrue,
+            reason: 'message "$msg" missing after rebuild',
+          );
+        }
+      });
+    },
+  );
+}
+
+class _LogViewer extends StatefulComponent {
+  @override
+  State<_LogViewer> createState() => _LogViewerState();
+}
+
+class _LogViewerState extends State<_LogViewer> {
+  final List<_Entry> _entries = [const _Entry('info', 'boot')];
+
+  void appendEntry(String level, String message) {
+    setState(() {
+      _entries.add(_Entry(level, message));
+    });
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return SizedBox(
+      width: 40,
+      height: 10,
+      child: ListView.builder(
+        itemCount: _entries.length,
+        itemExtent: 1,
+        itemBuilder: (context, index) => _LogRow(entry: _entries[index]),
+      ),
+    );
+  }
+}
+
+class _Entry {
+  const _Entry(this.level, this.message);
+  final String level;
+  final String message;
+}
+
+class _LogRow extends StatelessComponent {
+  const _LogRow({required this.entry});
+  final _Entry entry;
+
+  @override
+  Component build(BuildContext context) {
+    return Row(
+      children: [
+        Text(entry.level),
+        const SizedBox(width: 1),
+        Expanded(child: Text(entry.message)),
+      ],
+    );
+  }
+}

--- a/test/framework/layout_skip_value_equality_test.dart
+++ b/test/framework/layout_skip_value_equality_test.dart
@@ -1,0 +1,64 @@
+// The layout-skip check uses BoxConstraints value equality. This test
+// flips red if anyone swaps it back to `identical()`: a distinct-but-
+// value-equal BoxConstraints on a clean render object must not re-run
+// performLayout.
+
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'layout() skips performLayout when constraints are value-equal and clean',
+    () {
+      final render = _CountingRenderObject();
+
+      // First layout establishes size + constraints.
+      render.layout(
+        BoxConstraints(minWidth: 10, maxWidth: 10, minHeight: 1, maxHeight: 1),
+      );
+      expect(render.performLayoutCount, 1);
+
+      // A distinct-but-value-equal BoxConstraints must NOT trigger a
+      // re-layout. This is the invariant that fails under identical().
+      final distinctEqualConstraints = BoxConstraints(
+        minWidth: 10,
+        maxWidth: 10,
+        minHeight: 1,
+        maxHeight: 1,
+      );
+      expect(
+        identical(distinctEqualConstraints, render.lastConstraints),
+        isFalse,
+        reason: 'constructed from the same field values but must be a '
+            'separate instance - otherwise the test cannot distinguish '
+            '== from identical()',
+      );
+      expect(distinctEqualConstraints == render.lastConstraints, isTrue);
+
+      render.layout(distinctEqualConstraints);
+      expect(
+        render.performLayoutCount,
+        1,
+        reason: 'performLayout must not re-run when value-equal constraints '
+            'arrive and the render object is not dirty',
+      );
+
+      // But marking dirty does force re-layout, even with the same value.
+      render.markNeedsLayout();
+      render.layout(distinctEqualConstraints);
+      expect(render.performLayoutCount, 2);
+    },
+  );
+}
+
+class _CountingRenderObject extends RenderObject {
+  int performLayoutCount = 0;
+  BoxConstraints? lastConstraints;
+
+  @override
+  void performLayout() {
+    performLayoutCount++;
+    lastConstraints = constraints;
+    size = constraints.constrain(const Size(10, 1));
+  }
+}


### PR DESCRIPTION
## Summary

Retire the `identical()`-on-constraints workaround in `RenderObject.layout` and switch to value equality.  The workaround was masking three classes of missing `markNeedsLayout` calls. This PR fixes those at the source so the framework's intended layout-skip can engage without being defeated by parents that allocate fresh `BoxConstraints` each frame.

## Why

`RenderObject.layout` short-circuited on `identical(constraints, _constraints)`. 
Because every parent allocates a fresh `BoxConstraints` per frame, the skip almost never fired. 
Three call sites silently relied on that misfire:

- `LayoutBuilderElement.update` set `_needsBuild = true` but did not call `markNeedsLayout`. Builder closures from a parent rebuild never ran, so the LayoutBuilder subtree stayed stale unless something else triggered layout.
- `_ListViewportElement.update` set `_needsChildUpdate = true` but did not call `markNeedsLayout`. New items or fresh `itemBuilder` closures never rendered.
- `SelectionDragState` mutated globals without notifying anyone. Drag begin/end/range updates were only picked up by accident.
