### PR TITLE
fix(ticker): skip tail reschedule when onTick restarts the ticker

### DIFF
--- a/lib/src/animation/ticker.dart
+++ b/lib/src/animation/ticker.dart
@@ -197,6 +197,10 @@ class Ticker {
   void _scheduleTick({bool rescheduling = false}) {
     assert(!muted);
     assert(shouldScheduleTick);
+    assert(
+      _animationId == null,
+      'Ticker is already scheduled (id=$_animationId); rescheduling would orphan the prior callback.',
+    );
     // Match Flutter's pattern: call scheduleFrame() first, then register
     // the callback with scheduleNewFrame: false to avoid redundant scheduling.
     SchedulerBinding.instance.scheduleFrame();
@@ -224,7 +228,11 @@ class Ticker {
 
     _onTick(timeStamp - _startTime!);
 
-    if (shouldScheduleTick) {
+    // _onTick may have stopped and restarted this ticker
+    // (fx. an AnimationController status listener calling forward()),
+    // in which case _scheduleTick has already run and `_animationId != null`.
+    // Rescheduling here would overwrite that id and orphan the registered callback.
+    if (_animationId == null && shouldScheduleTick) {
       _scheduleTick(rescheduling: true);
     }
   }

--- a/test/animation/ticker_reentrant_test.dart
+++ b/test/animation/ticker_reentrant_test.dart
@@ -1,0 +1,56 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Ticker re-entrant restart', () {
+    late NoctermTestBinding binding;
+
+    setUp(() {
+      binding = NoctermTestBinding();
+    });
+
+    tearDown(() {
+      binding.shutdown();
+    });
+
+    test(
+      'restart from inside onTick does not orphan the prior callback',
+      () async {
+        // Mirrors the AnimationController scenario where a status listener calls
+        // forward(from: 0) when the simulation completes during _tick:
+        //   1. Frame fires Ticker._tick.
+        //   2. _onTick stops and restarts the ticker (registers a new transient
+        //      callback).
+        //   3. Ticker._tick must not reschedule itself a second time, or it
+        //      orphans the inner registration in the scheduler.
+        int tickCount = 0;
+        bool restarted = false;
+        late Ticker ticker;
+
+        ticker = Ticker((_) {
+          tickCount++;
+          if (!restarted) {
+            restarted = true;
+            ticker.stop();
+            ticker.start();
+          }
+        });
+
+        ticker.start();
+
+        final t1 = Duration(
+          microseconds: DateTime.now().microsecondsSinceEpoch,
+        );
+        binding.handleBeginFrame(t1);
+        expect(tickCount, 1);
+
+        // Without the fix, frame 2 would fire two callbacks (the orphan plus the
+        // outer reschedule), incrementing tickCount twice.
+        binding.handleBeginFrame(t1 + const Duration(milliseconds: 16));
+        expect(tickCount, 2);
+
+        ticker.dispose();
+      },
+    );
+  });
+}


### PR DESCRIPTION
If `onTick` stops and restarts the ticker re-entrantly, `start()` has already queued the next frame callback. 
The tail reschedule in `_tick` would overwrite `_animationId` and orphan the registration.

- Guard the tail reschedule on `_animationId == null`.
- Assert in `_scheduleTick` that no prior id is set.
