### PR TITLE
fix(windows): non-blocking input loop, restore Ctrl+C, drive-root path walk

### DIFF
--- a/lib/src/backend/win32_ansi_stdin.dart
+++ b/lib/src/backend/win32_ansi_stdin.dart
@@ -63,12 +63,16 @@ class Win32AnsiStdin extends Stream<List<int>> implements Stdin {
 
     try {
       while (_running) {
-        // Yield to Dart event loop
         await Future.delayed(Duration.zero);
-
         if (!_running) break;
 
-        // Read one input event
+        // Bounded wait keeps the Dart event loop responsive. Without this,
+        // ReadConsoleInputW parks the isolate until the next keystroke,
+        // starving timers and signal handlers.
+        final waitResult = _waitForSingleObject(_inputHandle, _pollIntervalMs);
+        if (!_running) break;
+        if (waitResult != _waitObject0) continue;
+
         final result =
             _readConsoleInputW(_inputHandle, pInputRecord, 1, pEventsRead);
         if (result != 0 && pEventsRead.value > 0) {
@@ -381,6 +385,12 @@ const int _enableMouseInput = 0x0010;
 const int _enableExtendedFlags = 0x0080;
 const int _enableQuickEditMode = 0x0040;
 
+// WaitForSingleObject return value: object is signaled.
+const int _waitObject0 = 0x00000000;
+
+// 16ms poll keeps the input loop responsive.
+const int _pollIntervalMs = 16;
+
 // Event types
 const int _keyEvent = 0x0001;
 const int _mouseEvent = 0x0002;
@@ -494,6 +504,11 @@ typedef _ReadConsoleInputDart = int Function(
     int nLength,
     Pointer<Uint32> lpNumberOfEventsRead);
 
+typedef _WaitForSingleObjectNative = Uint32 Function(
+    IntPtr hHandle, Uint32 dwMilliseconds);
+typedef _WaitForSingleObjectDart = int Function(
+    int hHandle, int dwMilliseconds);
+
 final _kernel32 = DynamicLibrary.open('kernel32.dll');
 
 final _getStdHandle = _kernel32
@@ -510,3 +525,7 @@ final _setConsoleMode =
 final _readConsoleInputW =
     _kernel32.lookupFunction<_ReadConsoleInputNative, _ReadConsoleInputDart>(
         'ReadConsoleInputW');
+
+final _waitForSingleObject = _kernel32.lookupFunction<
+    _WaitForSingleObjectNative,
+    _WaitForSingleObjectDart>('WaitForSingleObject');

--- a/lib/src/backend/win32_ansi_stdin.dart
+++ b/lib/src/backend/win32_ansi_stdin.dart
@@ -54,7 +54,21 @@ class Win32AnsiStdin extends Stream<List<int>> implements Stdin {
   void startEventLoop() {
     if (_running) return;
     _running = true;
+    // Dart's stdin.lineMode = false clears ENABLE_PROCESSED_INPUT, which is
+    // what makes Windows generate SIGINT for Ctrl+C.
+    _ensureProcessedInput();
     _eventLoop();
+  }
+
+  void _ensureProcessedInput() {
+    final modePtr = calloc<Uint32>();
+    try {
+      if (_getConsoleMode(_inputHandle, modePtr) != 0) {
+        _setConsoleMode(_inputHandle, modePtr.value | _enableProcessedInput);
+      }
+    } finally {
+      calloc.free(modePtr);
+    }
   }
 
   Future<void> _eventLoop() async {
@@ -381,6 +395,7 @@ class Win32AnsiStdin extends Stream<List<int>> implements Stdin {
 
 // Windows API Constants
 const int _stdInputHandle = -10;
+const int _enableProcessedInput = 0x0001;
 const int _enableMouseInput = 0x0010;
 const int _enableExtendedFlags = 0x0080;
 const int _enableQuickEditMode = 0x0040;

--- a/lib/src/utils/nocterm_paths.dart
+++ b/lib/src/utils/nocterm_paths.dart
@@ -30,20 +30,15 @@ String getNoctermDirectory() {
 String getProjectDirectory() {
   var parent = Directory.current;
   while (true) {
-    final newParent = parent.parent;
-
-    if (newParent == parent) {
-      throw StateError('Could not determine project directory');
-    }
-
     final pubspec = File(p.join(parent.path, 'pubspec.yaml'));
-    if (pubspec.existsSync()) {
-      return parent.path;
-    }
-    if (newParent.path == '/') {
-      return '/';
-    }
+    if (pubspec.existsSync()) return parent.path;
 
+    final newParent = parent.parent;
+    // Compare paths, not Directory identity — terminates at Windows drive
+    // roots where parent.parent returns the same path.
+    if (newParent.path == parent.path) {
+      return Directory.current.path;
+    }
     parent = newParent;
   }
 }

--- a/lib/src/utils/nocterm_paths.dart
+++ b/lib/src/utils/nocterm_paths.dart
@@ -28,6 +28,7 @@ String getNoctermDirectory() {
 }
 
 String getProjectDirectory() {
+  final start = Directory.current.path;
   var parent = Directory.current;
   while (true) {
     final pubspec = File(p.join(parent.path, 'pubspec.yaml'));
@@ -36,9 +37,7 @@ String getProjectDirectory() {
     final newParent = parent.parent;
     // Compare paths, not Directory identity — terminates at Windows drive
     // roots where parent.parent returns the same path.
-    if (newParent.path == parent.path) {
-      return Directory.current.path;
-    }
+    if (newParent.path == parent.path) return start;
     parent = newParent;
   }
 }

--- a/test/utils/nocterm_paths_test.dart
+++ b/test/utils/nocterm_paths_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:nocterm/src/utils/nocterm_paths.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('getProjectDirectory', () {
+    late Directory tempRoot;
+    late Directory previousCwd;
+
+    setUp(() {
+      previousCwd = Directory.current;
+      tempRoot = Directory.systemTemp.createTempSync('nocterm_paths_test_');
+    });
+
+    tearDown(() {
+      Directory.current = previousCwd;
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    test('returns the closest ancestor containing pubspec.yaml', () {
+      final project = Directory(p.join(tempRoot.path, 'project'))..createSync();
+      File(p.join(project.path, 'pubspec.yaml')).writeAsStringSync('name: x');
+      final nested = Directory(p.join(project.path, 'a', 'b'))
+        ..createSync(recursive: true);
+      Directory.current = nested;
+
+      expect(getProjectDirectory(), equals(project.path));
+    });
+
+    test('returns cwd when no pubspec.yaml ancestor exists', () {
+      final dir = Directory(p.join(tempRoot.path, 'a', 'b', 'c'))
+        ..createSync(recursive: true);
+      Directory.current = dir;
+
+      expect(getProjectDirectory(), equals(dir.path));
+    });
+
+    test('terminates when walking past the filesystem root', () {
+      final dir = Directory(p.join(tempRoot.path, 'deep', 'no', 'project'))
+        ..createSync(recursive: true);
+      Directory.current = dir;
+
+      expect(() => getProjectDirectory(), returnsNormally);
+    });
+  });
+}

--- a/test/utils/nocterm_paths_test.dart
+++ b/test/utils/nocterm_paths_test.dart
@@ -42,7 +42,7 @@ void main() {
         ..createSync(recursive: true);
       Directory.current = dir;
 
-      expect(() => getProjectDirectory(), returnsNormally);
+      expect(getProjectDirectory(), equals(dir.path));
     });
   });
 }


### PR DESCRIPTION
Fixes three Windows only issues:

### 1. `Win32AnsiStdin._eventLoop` blocks the Dart isolate
`ReadConsoleInputW` was called with no timeout, blocking the OS thread until input arrived. While blocked, no timers, futures, signal handlers, or render frames fire. The `await Future.delayed(Duration.zero)` at the top of the loop only yields between blocking calls.

Fix: call `WaitForSingleObject(handle, 16)` first; only call `ReadConsoleInputW` when the handle is signaled. Caps FFI time at ~16ms.

### 2. Ctrl+C path inactive on Windows
`enableRawMode` calls `stdin.lineMode = false`, which on Windows clears `ENABLE_PROCESSED_INPUT`. Without that flag, Windows doesn't generate `CTRL_C_EVENT`, so Dart's `ProcessSignal.sigint.watch()` doesn't fire.

Fix: re-assert `ENABLE_PROCESSED_INPUT` in `startEventLoop()`. With `ENABLE_LINE_INPUT` still off, only Ctrl+C is intercepted; other Ctrl+letter combos still arrive as key events.

### 3. `getProjectDirectory()` doesn't terminate on Windows drive roots
`if (newParent == parent)` is identity equality on `Directory` (`.parent` returns a new instance each call, so this never matches). `if (newParent.path == '/')` is POSIX-only. From a directory with no `pubspec.yaml` ancestor on Windows, the walk iterates on `C:\` indefinitely. Called synchronously from `LogServer._writePortFile()`, which is awaited in `_runApp` before `TerminalBinding.initialize()`, so `runApp` itself doesn't progress.

Fix: compare paths (`newParent.path == parent.path`), and fall back to `Directory.current.path` instead of throwing.

I also added new unit tests in `test/utils/nocterm_paths_test.dart` cover `getProjectDirectory`'s three behaviors