### PR TITLE
fix: stop sending DECRDA query on TUI shutdown

### DIFF
--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -859,10 +859,6 @@ class TerminalBinding extends NoctermBinding
       terminal.backend.writeRaw(EscapeCodes.disable.buttonEventTracking);
       terminal.backend.writeRaw(EscapeCodes.disable.basicMouseTracking);
 
-      // Send a terminal reset sequence as a final safety measure
-      // This helps ensure the terminal is in a clean state
-      terminal.backend.writeRaw(EscapeCodes.resetDeviceAttributes);
-
       terminal.clear();
 
       // Final flush to ensure all cleanup is complete

--- a/lib/src/utils/escape_codes.dart
+++ b/lib/src/utils/escape_codes.dart
@@ -4,7 +4,6 @@ class EscapeCodes {
   static const disable = _Disable._();
   static const enable = _Enable._();
 
-  static const resetDeviceAttributes = '\x1B[c';
   static const hideCursor = '\x1b[?25l';
   static const showCursor = '\x1b[?25h';
   static const clearScreen = '\x1b[2J';


### PR DESCRIPTION
`\x1B[c` requests device attributes, not a terminal reset. Terminals reply with e.g. `\x1B[?1;2c`, which can echo as stray `1;2c` text once cooked mode is restored after exit.