### PR TITLE
fix: stabilize IME cursor position to prevent Chinese input flickering

### DIFF
--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -1185,6 +1185,91 @@ class TerminalBinding extends NoctermBinding
     }
   }
 
+  /// Find the focused [RenderTextField] by walking the element tree.
+  ///
+  /// Looks for a [FocusableElement] whose [Focusable] component has
+  /// `focused == true` and which contains a [RenderTextField] in its
+  /// subtree. Returns `null` if no focused text field is found.
+  RenderTextField? _findFocusedRenderTextField() {
+    if (rootElement == null) return null;
+
+    // Walk the tree looking for a FocusableElement with focused == true
+    // that contains a RenderTextField
+    FocusableElement? focusedElement;
+    void findFocused(Element element) {
+      if (focusedElement != null) return;
+      if (element is FocusableElement && element.component.focused) {
+        focusedElement = element;
+        return;
+      }
+      element.visitChildren(findFocused);
+    }
+
+    findFocused(rootElement!);
+    if (focusedElement == null) return null;
+
+    // Now find the RenderTextField inside the focused element's subtree
+    RenderTextField? result;
+    void findTextField(Element element) {
+      if (result != null) return;
+      if (element is RenderObjectElement &&
+          element.renderObject is RenderTextField) {
+        result = element.renderObject as RenderTextField;
+        return;
+      }
+      element.visitChildren(findTextField);
+    }
+
+    findTextField(focusedElement!);
+    return result;
+  }
+
+  /// Position the physical terminal cursor at the IME composition position
+  /// of the focused text field (if any).
+  ///
+  /// When using an Input Method Editor (IME) such as Chinese Pinyin, the
+  /// terminal emulator displays the composition/preedit window at the
+  /// current cursor position. During differential rendering the cursor
+  /// jumps around the screen to write changed cells, causing the IME
+  /// window to flicker randomly.
+  ///
+  /// By repositioning the terminal cursor to the text field's cursor
+  /// location *after* every frame render, we give the IME a stable
+  /// anchor point. We also show the terminal cursor when a text field
+  /// is focused so that terminal emulators that require a visible cursor
+  /// for IME positioning work correctly.
+  void _positionImeCursor() {
+    final renderTextField = _findFocusedRenderTextField();
+    if (renderTextField == null) {
+      // No focused text field – hide the terminal cursor (normal TUI mode).
+      if (_imeCursorVisible) {
+        terminal.hideCursor();
+        _imeCursorVisible = false;
+      }
+      return;
+    }
+
+    final imePosition = renderTextField.getImeCursorPosition();
+    if (imePosition != null) {
+      // Move the physical terminal cursor to the text field's cursor position.
+      terminal.moveCursor(
+        imePosition.dx.round(),
+        imePosition.dy.round(),
+      );
+
+      // Show the terminal cursor so that IME composition windows
+      // (e.g. Chinese Pinyin) appear at the correct screen position.
+      if (!_imeCursorVisible) {
+        terminal.showCursor();
+        _imeCursorVisible = true;
+      }
+    }
+  }
+
+  /// Tracks whether the terminal cursor is currently visible (shown for IME).
+  /// We keep this in sync to avoid sending redundant show/hide sequences.
+  bool _imeCursorVisible = false;
+
   /// The actual frame drawing logic, registered as a persistent callback.
   void _drawFrameCallback(Duration timeStamp) {
     if (rootElement == null) return;
@@ -1295,6 +1380,12 @@ class TerminalBinding extends NoctermBinding
 
     // Render to terminal using differential rendering (buffer diff)
     _renderDifferential(buffer);
+
+    // After rendering, position the terminal cursor at the focused text
+    // field's cursor location. This stabilises the IME composition window
+    // (e.g. Chinese Pinyin) so it doesn't flicker across the screen.
+    _positionImeCursor();
+    terminal.flush();
 
     if (profiling) {
       t5 = DateTime.now().microsecondsSinceEpoch;

--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -1020,7 +1020,17 @@ class TerminalBinding extends NoctermBinding
     // Render pending sixel images
     _renderPendingImages(buffer);
 
-    terminal.flush();
+    // Intentionally do NOT flush here. Flushing inside the differential
+    // render causes the frame to be split into two pipe writes: the cell
+    // diff first (leaving the terminal cursor on whatever cell the diff
+    // happened to write last), then any subsequent write from the caller.
+    // On terminals that follow the cursor for IME composition windows
+    // (e.g. Windows Terminal with Chinese / Japanese / Korean IMEs), this
+    // split causes the IME composition window to flicker between the
+    // last streaming cell and the input field's caret.
+    //
+    // Letting the caller flush once after rendering the frame keeps the
+    // cursor at a single, stable position for the whole frame.
   }
 
   /// Full redraw (used for first frame or after resize).
@@ -1089,7 +1099,9 @@ class TerminalBinding extends NoctermBinding
     // Render pending sixel images
     _renderPendingImages(buffer);
 
-    terminal.flush();
+    // Intentionally do NOT flush here. See _renderFullDiff for the full
+    // rationale; the same split-frame issue applies here on the
+    // first-frame / post-resize path.
   }
 
   // Detailed timing instrumentation for profiling

--- a/lib/src/components/text_field.dart
+++ b/lib/src/components/text_field.dart
@@ -1375,6 +1375,65 @@ class RenderTextField extends RenderObject with MouseTrackerAnnotationProvider {
     _targetVisualColumn = null;
   }
 
+  /// Returns the terminal screen coordinates (column, row) of the text cursor,
+  /// or null if the cursor position cannot be determined or the field is not focused.
+  ///
+  /// This is used by the binding layer to position the physical terminal cursor
+  /// so that IME (Input Method Editor) composition windows (e.g. Chinese Pinyin)
+  /// appear at the correct location instead of flickering across the screen
+  /// during differential rendering.
+  ///
+  /// The position is returned even when the cursor is in its blink-off phase
+  /// so the IME window stays anchored at the correct location.
+  Offset? getImeCursorPosition() {
+    if (!_isFocused || _layoutResult == null) {
+      return null;
+    }
+
+    final lines = _layoutResult!.lines;
+
+    if (_text.isEmpty && _placeholder == null) {
+      // Empty field - cursor at beginning
+      final globalOffset = _globalPaintOffset;
+      return Offset(globalOffset.dx, globalOffset.dy);
+    }
+
+    // Find which line the cursor is on (same logic as _paintCursor)
+    int charCount = 0;
+    for (int i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      final lineLength = line.length;
+
+      if (charCount + lineLength >= _selection.extentOffset ||
+          i == lines.length - 1) {
+        final positionInLine =
+            (_selection.extentOffset - charCount).clamp(0, lineLength);
+
+        // Calculate visual position using Unicode width
+        final textBeforeCursor = line.substring(0, positionInLine);
+        final visualColumn = UnicodeWidth.stringWidth(textBeforeCursor);
+
+        // Combine global offset with cursor position within the field
+        final globalOffset = _globalPaintOffset;
+        return Offset(
+          globalOffset.dx + visualColumn,
+          globalOffset.dy + i,
+        );
+      }
+
+      charCount += lineLength;
+      if (i < lines.length - 1) {
+        final textSoFar =
+            _text.substring(0, math.min(charCount, _text.length));
+        if (textSoFar.endsWith('\n')) {
+          charCount++;
+        }
+      }
+    }
+
+    return null;
+  }
+
   // --- Mouse interaction ---
 
   @override

--- a/lib/src/components/text_field.dart
+++ b/lib/src/components/text_field.dart
@@ -1422,12 +1422,13 @@ class RenderTextField extends RenderObject with MouseTrackerAnnotationProvider {
       }
 
       charCount += lineLength;
-      if (i < lines.length - 1) {
-        final textSoFar =
-            _text.substring(0, math.min(charCount, _text.length));
-        if (textSoFar.endsWith('\n')) {
-          charCount++;
-        }
+      // Only add 1 for actual newline characters, not wrapped lines.
+      // Check the character right after this line's content in the
+      // original text.
+      if (i < lines.length - 1 &&
+          charCount < _text.length &&
+          _text[charCount] == '\n') {
+        charCount++;
       }
     }
 
@@ -1809,13 +1810,14 @@ class RenderTextField extends RenderObject with MouseTrackerAnnotationProvider {
       }
 
       charCount += lineLength;
-      // Only add 1 for actual newline characters, not wrapped lines
-      // Check if the accumulated text so far ends with a newline
-      if (i < lines.length - 1) {
-        final textSoFar = _text.substring(0, math.min(charCount, _text.length));
-        if (textSoFar.endsWith('\n')) {
-          charCount++; // Account for the newline character
-        }
+      // Only add 1 for actual newline characters, not wrapped lines.
+      // Check the character right after this line's content in the
+      // original text — if it's a newline, the layout engine split
+      // on it, so we must account for the extra byte.
+      if (i < lines.length - 1 &&
+          charCount < _text.length &&
+          _text[charCount] == '\n') {
+        charCount++;
       }
     }
   }


### PR DESCRIPTION
After each frame render, reposition the terminal's physical cursor to the focused text field's cursor location. This gives IME (Input Method Editor) composition windows a stable anchor point, preventing them from flickering across the screen during differential rendering updates.

- Add RenderTextField.getImeCursorPosition() to compute screen coordinates of the text cursor (same logic as _paintCursor but returns position)
- Add TerminalBinding._positionImeCursor() to move terminal cursor after each frame render and show/hide it based on text field focus
- Add TerminalBinding._findFocusedRenderTextField() to locate the focused RenderTextField via FocusableElement