### PR TITLE
perf: improve terminal frame pacing and diff rendering

### DIFF
--- a/lib/src/binding/scheduler_binding.dart
+++ b/lib/src/binding/scheduler_binding.dart
@@ -161,6 +161,8 @@ mixin SchedulerBinding on NoctermBinding {
   final List<FrameTimingCallback> _frameTimingCallbacks = [];
   int _frameNumber = 0;
   DateTime? _lastFrameTime;
+  DateTime? _nextFrameTargetTime;
+  Duration? _lastPacingTargetFrameDuration;
 
   /// Returns the time of the last frame execution.
   ///
@@ -487,31 +489,52 @@ mixin SchedulerBinding on NoctermBinding {
   /// Subclasses can override for different timing strategies (e.g., vsync).
   @protected
   void scheduleFrameImpl() {
-    // Don't schedule if a timer is already pending
+    scheduleFrameTimer(executeFrame);
+  }
+
+  /// Schedules [onFrame] using the shared frame pacing logic.
+  ///
+  /// Subclasses that need custom frame execution can call this helper instead
+  /// of duplicating the limiter. The limiter tracks the next target frame time
+  /// separately from the last actual frame start, so small timer overshoots are
+  /// compensated for on following frames instead of permanently lowering FPS.
+  @protected
+  void scheduleFrameTimer(VoidCallback onFrame) {
     if (pendingFrameTimer != null && pendingFrameTimer!.isActive) {
       return;
     }
 
-    if (enableFrameRateLimiting && _lastFrameTime != null) {
-      final now = DateTime.now();
-      final elapsed = now.difference(_lastFrameTime!);
+    final delay = frameDelayFrom(DateTime.now());
+    pendingFrameTimer = Timer(delay, () {
+      pendingFrameTimer = null;
+      onFrame();
+    });
+  }
 
-      if (elapsed < targetFrameDuration) {
-        // Too soon, delay the frame
-        final delay = targetFrameDuration - elapsed;
-        pendingFrameTimer = Timer(delay, () {
-          pendingFrameTimer = null;
-          executeFrame();
-        });
-        return;
-      }
+  /// Returns the delay required before the next frame may begin.
+  ///
+  /// This is protected primarily for tests and platform-specific bindings that
+  /// need to inspect pacing behavior.
+  @protected
+  Duration frameDelayFrom(DateTime now) {
+    if (!enableFrameRateLimiting ||
+        targetFrameDuration.inMicroseconds <= 0 ||
+        _lastFrameTime == null) {
+      return Duration.zero;
     }
 
-    // Execute frame immediately (but still async to allow event loop to process)
-    pendingFrameTimer = Timer(Duration.zero, () {
-      pendingFrameTimer = null;
-      executeFrame();
-    });
+    if (_lastPacingTargetFrameDuration != targetFrameDuration) {
+      _lastPacingTargetFrameDuration = targetFrameDuration;
+      _nextFrameTargetTime = _lastFrameTime!.add(targetFrameDuration);
+    } else {
+      _nextFrameTargetTime ??= _lastFrameTime!.add(targetFrameDuration);
+    }
+
+    if (!now.isBefore(_nextFrameTargetTime!)) {
+      return Duration.zero;
+    }
+
+    return _nextFrameTargetTime!.difference(now);
   }
 
   /// Executes a single frame by recording the time and calling [handleBeginFrame].
@@ -520,11 +543,56 @@ mixin SchedulerBinding on NoctermBinding {
   /// (e.g., waking an event loop after frame execution).
   @protected
   void executeFrame() {
-    _lastFrameTime = DateTime.now();
+    final frameTime = DateTime.now();
+    recordFrameStart(frameTime);
     final timeStamp =
         Duration(microseconds: _lastFrameTime!.microsecondsSinceEpoch);
     handleBeginFrame(timeStamp);
   }
+
+  /// Records the start time for a frame and advances pacing state.
+  @protected
+  void recordFrameStart(DateTime frameTime) {
+    updateFramePacing(frameTime);
+    _lastFrameTime = frameTime;
+  }
+
+  /// Advances the pacing target after a frame starts.
+  ///
+  /// If a timer fires late, this moves the next target by whole frame intervals
+  /// from the previous target rather than from the late actual start time. That
+  /// lets subsequent frames catch up to the requested average frame rate.
+  @protected
+  void updateFramePacing(DateTime frameTime) {
+    if (!enableFrameRateLimiting || targetFrameDuration.inMicroseconds <= 0) {
+      _nextFrameTargetTime = null;
+      _lastPacingTargetFrameDuration = null;
+      return;
+    }
+
+    final targetChanged = _lastPacingTargetFrameDuration != targetFrameDuration;
+    _lastPacingTargetFrameDuration = targetFrameDuration;
+
+    if (_lastFrameTime == null ||
+        _nextFrameTargetTime == null ||
+        targetChanged) {
+      _nextFrameTargetTime = frameTime.add(targetFrameDuration);
+      return;
+    }
+
+    if (frameTime.isBefore(_nextFrameTargetTime!)) {
+      return;
+    }
+
+    final lateBy = frameTime.difference(_nextFrameTargetTime!).inMicroseconds;
+    final missedIntervals = (lateBy ~/ targetFrameDuration.inMicroseconds) + 1;
+    _nextFrameTargetTime = _nextFrameTargetTime!.add(Duration(
+      microseconds: targetFrameDuration.inMicroseconds * missedIntervals,
+    ));
+  }
+
+  @visibleForTesting
+  DateTime? get debugNextFrameTargetTime => _nextFrameTargetTime;
 
   /// Ensures a visual update occurs.
   ///

--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -958,6 +958,8 @@ class TerminalBinding extends NoctermBinding
     TextStyle? currentStyle;
 
     for (int y = 0; y < buffer.height; y++) {
+      int? expectedCursorX;
+
       for (int x = 0; x < buffer.width; x++) {
         final cell = buffer.getCell(x, y);
         final prevCell = previous.getCell(x, y);
@@ -977,8 +979,13 @@ class TerminalBinding extends NoctermBinding
           continue;
         }
 
-        // Cell changed - move cursor and write
-        terminal.moveCursor(x, y);
+        // The terminal cursor advances after writes, so adjacent changed cells
+        // can be emitted as one run. Scrolling commonly changes nearly every
+        // cell in a row; avoiding an absolute cursor move per cell keeps those
+        // frames small enough for Windows terminals and ConPTY.
+        if (expectedCursorX != x) {
+          terminal.moveCursor(x, y);
+        }
 
         // Handle style
         final hasStyle = cell.style.color != null ||
@@ -1005,6 +1012,8 @@ class TerminalBinding extends NoctermBinding
           }
           terminal.write(cell.char);
         }
+
+        expectedCursorX = x + cell.width;
       }
     }
 

--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -880,33 +880,7 @@ class TerminalBinding extends NoctermBinding
   @override
   void scheduleFrameImpl() {
     // Override scheduler's frame implementation to also wake the event loop.
-    // Uses pendingFrameTimer from SchedulerBinding for rate limiting.
-
-    // Don't schedule if a timer is already pending
-    if (pendingFrameTimer != null && pendingFrameTimer!.isActive) {
-      return;
-    }
-
-    if (enableFrameRateLimiting && lastFrameTime != null) {
-      final now = DateTime.now();
-      final elapsed = now.difference(lastFrameTime!);
-
-      if (elapsed < targetFrameDuration) {
-        // Too soon, delay the frame
-        final delay = targetFrameDuration - elapsed;
-        pendingFrameTimer = Timer(delay, () {
-          pendingFrameTimer = null;
-          _executeFrameAndWakeEventLoop();
-        });
-        return;
-      }
-    }
-
-    // Execute frame immediately (but still async to allow event loop to process)
-    pendingFrameTimer = Timer(Duration.zero, () {
-      pendingFrameTimer = null;
-      _executeFrameAndWakeEventLoop();
-    });
+    scheduleFrameTimer(_executeFrameAndWakeEventLoop);
   }
 
   /// Executes frame and wakes the event loop.

--- a/test/foundation/scheduler_batching_test.dart
+++ b/test/foundation/scheduler_batching_test.dart
@@ -128,6 +128,62 @@ void main() {
       );
     });
   });
+
+  group('SchedulerBinding frame pacing', () {
+    late TestFramePacingBinding binding;
+
+    setUp(() {
+      binding = TestFramePacingBinding();
+      binding.targetFrameDuration = FrameRate.fps30;
+    });
+
+    tearDown(() {
+      binding.shutdown();
+    });
+
+    test('compensates for timer overshoot instead of accumulating drift', () {
+      final firstFrame = DateTime.utc(2026, 1, 1);
+
+      binding.frameStartedAt(firstFrame);
+      expect(
+        binding.debugNextFrameTargetTime,
+        firstFrame.add(FrameRate.fps30),
+      );
+
+      final lateSecondFrame = firstFrame.add(
+        FrameRate.fps30 + const Duration(milliseconds: 2),
+      );
+      binding.frameStartedAt(lateSecondFrame);
+
+      final thirdFrameTarget = firstFrame.add(FrameRate.fps30 * 2);
+      expect(binding.debugNextFrameTargetTime, thirdFrameTarget);
+
+      final afterSecondFrameWork =
+          lateSecondFrame.add(const Duration(milliseconds: 1));
+      expect(
+        binding.delayFrom(afterSecondFrameWork),
+        thirdFrameTarget.difference(afterSecondFrameWork),
+      );
+      expect(
+        binding.delayFrom(afterSecondFrameWork),
+        FrameRate.fps30 - const Duration(milliseconds: 3),
+      );
+    });
+  });
+}
+
+class TestFramePacingBinding extends NoctermBinding with SchedulerBinding {
+  void frameStartedAt(DateTime frameTime) {
+    recordFrameStart(frameTime);
+  }
+
+  Duration delayFrom(DateTime now) {
+    return frameDelayFrom(now);
+  }
+
+  void shutdown() {
+    NoctermBinding.resetInstance();
+  }
 }
 
 // Test component that counts builds

--- a/test/rendering/terminal_diff_output_test.dart
+++ b/test/rendering/terminal_diff_output_test.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('differential renderer batches adjacent cells and tracks wide glyphs',
+      () async {
+    final backend = _CapturingBackend(const Size(12, 2));
+    final binding = _TestTerminalBinding(Terminal(backend));
+    late _MutableTextState state;
+
+    binding.attachRootComponent(
+      _MutableText(onStateCreated: (value) => state = value),
+    );
+    binding.pump();
+    backend.clear();
+
+    state.setText('BBBB');
+    await Future<void>.delayed(FrameRate.fps30);
+
+    final output = backend.output;
+    expect(output, contains('BBBB'));
+    expect(_cursorMoveCount(output), 1);
+
+    backend.clear();
+
+    state.setText('你C');
+    await Future<void>.delayed(FrameRate.fps30);
+
+    final wideOutput = backend.output;
+    expect(wideOutput, contains('你C'));
+    expect(_cursorMoveCount(wideOutput), 1);
+
+    binding.shutdown();
+  });
+}
+
+int _cursorMoveCount(String output) {
+  return RegExp(r'\x1b\[\d+;\d+H').allMatches(output).length;
+}
+
+class _TestTerminalBinding extends TerminalBinding {
+  _TestTerminalBinding(super.terminal);
+
+  void pump() => executeFrame();
+}
+
+class _MutableText extends StatefulComponent {
+  const _MutableText({required this.onStateCreated});
+
+  final void Function(_MutableTextState) onStateCreated;
+
+  @override
+  State<_MutableText> createState() => _MutableTextState();
+}
+
+class _MutableTextState extends State<_MutableText> {
+  String text = 'AAAA';
+
+  @override
+  void initState() {
+    super.initState();
+    component.onStateCreated(this);
+  }
+
+  void setText(String value) {
+    setState(() => text = value);
+  }
+
+  @override
+  Component build(BuildContext context) => Text(text);
+}
+
+class _CapturingBackend implements TerminalBackend {
+  _CapturingBackend(this._size);
+
+  final Size _size;
+  final StringBuffer _output = StringBuffer();
+
+  String get output => _output.toString();
+
+  void clear() => _output.clear();
+
+  @override
+  void writeRaw(String data) => _output.write(data);
+
+  @override
+  Size getSize() => _size;
+
+  @override
+  bool get supportsSize => true;
+
+  @override
+  void notifySizeChanged(Size newSize) {}
+
+  @override
+  Stream<List<int>>? get inputStream => const Stream<List<int>>.empty();
+
+  @override
+  Stream<Size>? get resizeStream => null;
+
+  @override
+  Stream<void>? get shutdownStream => null;
+
+  @override
+  Stream<void>? get resumeStream => null;
+
+  @override
+  void enableRawMode() {}
+
+  @override
+  void disableRawMode() {}
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  void requestExit([int exitCode = 0]) {}
+
+  @override
+  void dispose() {}
+}

--- a/test/rendering/terminal_diff_output_test.dart
+++ b/test/rendering/terminal_diff_output_test.dart
@@ -104,9 +104,6 @@ class _CapturingBackend implements TerminalBackend {
   Stream<void>? get shutdownStream => null;
 
   @override
-  Stream<void>? get resumeStream => null;
-
-  @override
   void enableRawMode() {}
 
   @override


### PR DESCRIPTION
## Summary

- Batch adjacent changed terminal cells during differential rendering to reduce cursor moves and write overhead.
- Share scheduler frame pacing logic between bindings.
- Track the next target frame time independently from late timer callbacks, so small overshoots do not permanently lower effective FPS.
- Add focused regression coverage for contiguous diff writes, wide glyphs, batching, and frame pacing drift.

## Tests

- `dart analyze`
- `dart test test/rendering/terminal_diff_output_test.dart test/foundation/scheduler_batching_test.dart`
