### PR TITLE
Fix stale mouse tracker state

### DIFF
--- a/lib/src/rendering/mouse_tracker.dart
+++ b/lib/src/rendering/mouse_tracker.dart
@@ -53,12 +53,10 @@ class MouseTracker {
   final Set<MouseButton> _pressedButtons = {};
 
   /// Update the hovered annotations based on hit test results and dispatch events.
-  void updateAnnotations(
-    MouseHitTestResult hitTestResult,
-    MouseEvent event,
-  ) {
+  void updateAnnotations(MouseHitTestResult hitTestResult, MouseEvent event) {
     _updatePressedButtons(event);
     final effectiveEvent = _eventWithButtons(event);
+    _hoveredAnnotations.removeWhere((a) => !a.validForMouseTracker);
 
     // Collect all annotations from the hit test result
     final Set<MouseTrackerAnnotation> newAnnotations = {};
@@ -97,7 +95,9 @@ class MouseTracker {
 
     // Update the set of hovered annotations
     _hoveredAnnotations.clear();
-    _hoveredAnnotations.addAll(newAnnotations);
+    _hoveredAnnotations.addAll(
+      newAnnotations.where((a) => a.validForMouseTracker),
+    );
   }
 
   /// Clear all hovered annotations (e.g., when mouse leaves the terminal).
@@ -109,14 +109,13 @@ class MouseTracker {
     _pressedButtons.clear();
   }
 
-  /// Track pressed buttons from non-motion press/release events.
+  /// Track pressed buttons from press/release events.
   void _updatePressedButtons(MouseEvent event) {
-    // Ignore wheel and motion-only events
+    // Ignore wheel events; they do not change button state.
     if (event.button == MouseButton.wheelUp ||
         event.button == MouseButton.wheelDown) {
       return;
     }
-    if (event.isMotion) return;
 
     if (event.pressed) {
       _pressedButtons.add(event.button);

--- a/test/input/mouse_button_state_test.dart
+++ b/test/input/mouse_button_state_test.dart
@@ -1,0 +1,59 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Mouse button state', () {
+    testNocterm('motion release after normal press clears button', (
+      tester,
+    ) async {
+      int tapCount = 0;
+
+      await tester.pumpComponent(
+        Container(
+          width: 80,
+          height: 24,
+          child: GestureDetector(
+            onTap: () => tapCount++,
+            child: Container(
+              width: 20,
+              height: 5,
+              child: const Center(child: Text('[Click me]')),
+            ),
+          ),
+        ),
+      );
+
+      await tester.sendMouseEvent(
+        const MouseEvent(
+          button: MouseButton.left,
+          x: 10,
+          y: 2,
+          pressed: true,
+        ),
+      );
+
+      await tester.sendMouseEvent(
+        const MouseEvent(
+          button: MouseButton.left,
+          x: 10,
+          y: 2,
+          pressed: false,
+          isMotion: true,
+        ),
+      );
+
+      expect(
+        tapCount,
+        1,
+        reason: 'Motion-marked release should still complete the click',
+      );
+
+      await tester.tap(10, 2);
+      expect(
+        tapCount,
+        2,
+        reason: 'Subsequent clicks should not inherit a stuck button state',
+      );
+    });
+  });
+}

--- a/test/input/mouse_tracker_test.dart
+++ b/test/input/mouse_tracker_test.dart
@@ -1,0 +1,66 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:nocterm/src/rendering/mouse_hit_test.dart';
+import 'package:nocterm/src/rendering/mouse_tracker.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MouseTracker', () {
+    test('does not keep annotations invalidated during hover dispatch', () {
+      final tracker = MouseTracker();
+      final renderObject = _AnnotationRenderObject();
+      int exitCount = 0;
+
+      late final MouseTrackerAnnotation annotation;
+      annotation = MouseTrackerAnnotation(
+        onHover: (_) {
+          annotation.validForMouseTracker = false;
+        },
+        onExit: (_) {
+          exitCount++;
+        },
+        renderObject: renderObject,
+      );
+      renderObject.annotation = annotation;
+
+      final result = MouseHitTestResult()
+        ..addWithPosition(target: renderObject, localPosition: Offset.zero);
+
+      tracker.updateAnnotations(
+        result,
+        const MouseEvent(
+          button: MouseButton.left,
+          x: 0,
+          y: 0,
+          pressed: false,
+          isMotion: true,
+        ),
+      );
+      tracker.clear(
+        const MouseEvent(
+          button: MouseButton.left,
+          x: 1,
+          y: 1,
+          pressed: false,
+          isMotion: true,
+        ),
+      );
+
+      expect(
+        exitCount,
+        0,
+        reason: 'Invalid annotations should not be retained for later events',
+      );
+    });
+  });
+}
+
+class _AnnotationRenderObject extends RenderObject
+    with MouseTrackerAnnotationProvider {
+  @override
+  MouseTrackerAnnotation? annotation;
+
+  @override
+  void performLayout() {
+    size = Size.zero;
+  }
+}


### PR DESCRIPTION
## Summary
- keep pressed mouse button state current for motion-marked press/release events
- drop invalid mouse annotations before and after dispatch so detached regions are not retained
- add regressions for motion-marked release and annotations invalidated during hover dispatch

## Tests
- dart test test/input/mouse_button_state_test.dart test/input/mouse_tracker_test.dart test/input/mouse_region_test.dart test/input/gesture_detector_test.dart
- dart test test/input/click_bug_reproduction_test.dart