### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 0.8.0
+
+## Bug Fixes
+- **IME composition (Windows/CJK)**: Emit each rendered frame in a single pipe write so the terminal never anchors the IME composition window to a transient streaming cell — fixes IME window flickering across the screen during chat/log streaming
+- **IME cursor**: Stabilize IME cursor position to prevent Chinese input flickering
+- **TextField cursor**: Correct cursor position with multiple consecutive newlines
+- **Windows input**: Restore `ENABLE_PROCESSED_INPUT` so Ctrl+C generates SIGINT
+- **Windows input**: Cap the input loop wait so timers and signals fire reliably
+- **Win32 input**: Encode `KEY_EVENT_RECORD.uChar` as UTF-8 for correct IME input
+- **Win32 mouse**: Forward bare mouse motion as SGR button 35 so hover works
+- **Character width**: Keep East Asian Ambiguous punctuation single-width
+- **Selection**: Edge auto-scroll during selection drag in scroll views
+- **Terminal shutdown**: Stop sending DECRDA query on TUI shutdown
+- **Project paths**: Terminate `getProjectDirectory` walk at Windows drive roots
+- **TextField**: Use `InputDecoration` instead of `BoxDecoration`
+
+## Refactoring
+- **Character width**: Delegate CJK classification to the xterm wcwidth table
+
+## Chores
+- **CI**: Bump GitHub Actions to node24-compatible majors
+- Strengthen the test suite with additional matchers, audit fixes, and gap coverage
+
+---
+
 # 0.7.0
 
 ## Layout pipeline

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ```yaml
 dependencies:
-  nocterm: ^0.7.0
+  nocterm: ^0.8.0
 ```
 
 ## Quick Start

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nocterm
 description: A Flutter-like framework for building rich terminal user interfaces with components, state management, animations, and more.
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/Norbert515/nocterm
 homepage: https://docs.nocterm.dev
 documentation: https://docs.nocterm.dev


### PR DESCRIPTION
Bumps the version to 0.8.0 and updates the changelog with everything that's landed since 0.7.0

@Norbert515 Wanted to get your approval before pushing a new release tag! Please review when you have some free time, and once it's approved/merged I'll push the v0.8.0 tag.