### PR TITLE
fix(input): route IME text as a key event, keep clipboard clean on paste

### DIFF
--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -271,16 +271,26 @@ class TerminalBinding extends NoctermBinding
           // Route the mouse event through the component tree
           _routeMouseEvent(mouseEvent);
         } else if (event is PasteInputEvent) {
-          // Handle bracketed paste (or batched characters): copy to clipboard then send Ctrl+V
-          ClipboardManager.copy(event.text);
+          // Stash the text on the binding and route a synthetic
+          // Ctrl+V. We deliberately don't call ClipboardManager.copy
+          // here: on macOS the IME wraps committed text in
+          // bracketed-paste markers, so a real copy would clobber
+          // the user's clipboard every time they confirm a
+          // candidate. The focused widget picks up the text via
+          // NoctermBinding.instance.consumePendingPasteText in
+          // its paste path.
+          setPendingPasteText(event.text);
 
-          // Generate a Ctrl+V keyboard event to trigger the paste
           final pasteEvent = KeyboardEvent(
             logicalKey: LogicalKey.keyV,
             modifiers: const ModifierKeys(ctrl: true),
           );
           _keyboardEventController.add(pasteEvent);
           _routeKeyboardEvent(pasteEvent);
+          // Drop the text if no widget consumed it (e.g. focus on a
+          // non-pasteable widget), so a subsequent real Ctrl+V
+          // doesn't pick up stale IME text. Idempotent.
+          consumePendingPasteText();
         }
       }
 

--- a/lib/src/components/text_field.dart
+++ b/lib/src/components/text_field.dart
@@ -852,8 +852,14 @@ class _TextFieldState extends State<TextField> {
   }
 
   void _paste() {
-    // Paste text from clipboard
-    var clipboardText = ClipboardManager.paste();
+    // Prefer framework-stashed paste text (set by TerminalBinding
+    // for a PasteInputEvent) over the system clipboard, so IME-
+    // committed text on macOS — which the IME wraps in bracketed-
+    // paste markers — doesn't clobber the user's clipboard. Real
+    // Ctrl+V has no pending text and falls through to the
+    // clipboard as before.
+    var clipboardText = NoctermBinding.instance.consumePendingPasteText() ??
+        ClipboardManager.paste();
     if (clipboardText != null && clipboardText.isNotEmpty) {
       if (component.maxLines == 1) {
         // Single-line field: replace all newlines/carriage returns with spaces

--- a/lib/src/framework/binding.dart
+++ b/lib/src/framework/binding.dart
@@ -74,6 +74,28 @@ abstract class NoctermBinding {
     _instance = null;
   }
 
+  /// Next paste payload stashed by `TerminalBinding` for a
+  /// `PasteInputEvent`. Set instead of writing to the system
+  /// clipboard so IME-committed text (which on macOS arrives as
+  /// a bracketed-paste payload) doesn't clobber whatever the
+  /// user had on their clipboard.
+  String? _pendingPasteText;
+
+  void setPendingPasteText(String text) {
+    _pendingPasteText = text;
+  }
+
+  String? consumePendingPasteText() {
+    final text = _pendingPasteText;
+    _pendingPasteText = null;
+    return text;
+  }
+
+  @visibleForTesting
+  void setPendingPasteTextForTest(String text) {
+    _pendingPasteText = text;
+  }
+
   BuildOwner? _buildOwner;
   BuildOwner get buildOwner => _buildOwner ??= createBuildOwner();
 

--- a/lib/src/keyboard/input_parser.dart
+++ b/lib/src/keyboard/input_parser.dart
@@ -795,41 +795,36 @@ class InputParser {
   /// Parse kitty keyboard protocol sequence: CSI codepoint ; modifier u
   /// Supports `:` sub-parameters per the kitty spec (e.g. \x1b[13:10;2u).
   /// Example: \x1b[13;2u = Enter with Shift
+  ///
+  /// Also supports the 4-part form `CSI codepoint ; modifier ;
+  /// base_layout ; associated_text u` used by terminals to surface
+  /// IME-committed text. The associated text is percent-encoded
+  /// UTF-8 (so "你好" arrives as "%E4%BD%A0%E5%A5%BD").
   (KeyboardEvent, int)? _parseKittySequence() {
-    // Find 'u' terminator (0x75)
-    // Valid parameter bytes: digits (0x30-0x39), ';' (0x3B), ':' (0x3A)
-    int uIndex = -1;
-    for (int i = 2; i < _buffer.length; i++) {
-      if (_buffer[i] == 0x75) {
-        // 'u'
-        uIndex = i;
+    // Scan backward for the 'u' terminator and pick the last one
+    // that yields a well-formed 1–4 part sequence. The backward
+    // scan is needed because the associated text can contain a
+    // raw 'u' (it's unreserved in URL percent-encoding, so
+    // terminals don't encode it).
+    int? terminatorIndex;
+    for (int i = _buffer.length - 1; i >= 2; i--) {
+      if (_buffer[i] != 0x75) continue;
+      final parts =
+          String.fromCharCodes(_buffer.sublist(2, i)).split(';');
+      if (_isValidKittyParts(parts)) {
+        terminatorIndex = i;
         break;
       }
-      // If we hit a non-parameter byte that isn't 'u', this isn't a kitty sequence
-      if (_buffer[i] != 0x3B && // ';'
-          _buffer[i] != 0x3A && // ':' (sub-parameter separator)
-          !(_buffer[i] >= 0x30 && _buffer[i] <= 0x39)) {
-        // not a digit
-        return null;
-      }
     }
+    if (terminatorIndex == null) return null;
 
-    if (uIndex == -1) return null; // No 'u' terminator found yet
+    final parts =
+        String.fromCharCodes(_buffer.sublist(2, terminatorIndex)).split(';');
 
-    // Extract the parameter string between '[' and 'u'
-    final paramStr = String.fromCharCodes(_buffer.sublist(2, uIndex));
-    final parts = paramStr.split(';');
-
-    if (parts.isEmpty || parts.length > 3) return null;
-
-    // The codepoint field may contain `:` sub-parameters (e.g. "13:10").
-    // Per the kitty spec, the first value is the Unicode codepoint.
     final codepointStr = parts[0].split(':').first;
     final codepoint = int.tryParse(codepointStr);
     if (codepoint == null) return null;
 
-    // The modifier field may also contain `:` sub-parameters (e.g. "2:1").
-    // The first value is the modifier bitmask.
     final modifierStr = parts.length >= 2 ? parts[1].split(':').first : null;
     final modifierValue =
         modifierStr != null ? int.tryParse(modifierStr) : null;
@@ -837,10 +832,93 @@ class InputParser {
         ? _decodeModifiers(modifierValue)
         : const ModifierKeys();
 
-    final totalBytes = uIndex + 1; // Include the 'u' terminator
-    final keyEvent = _codepointToKeyEvent(codepoint, modifiers);
+    final totalBytes = terminatorIndex + 1;
 
-    return (keyEvent, totalBytes);
+    // 4-part form: associated text becomes the character;
+    // the codepoint still drives the logical key.
+    if (parts.length == 4) {
+      var rawText = parts[3];
+      if (rawText.endsWith(' ')) {
+        rawText = rawText.substring(0, rawText.length - 1);
+      }
+      final associatedText = _decodePercentEncoded(rawText);
+      if (associatedText.isNotEmpty) {
+        return (
+          KeyboardEvent(
+            logicalKey: _logicalKeyForCodepoint(codepoint),
+            character: associatedText,
+            modifiers: modifiers,
+          ),
+          totalBytes,
+        );
+      }
+      // Empty associated text: treat as 3-part, fall through.
+    }
+
+    return (_codepointToKeyEvent(codepoint, modifiers), totalBytes);
+  }
+
+  /// True if [parts] is a structurally well-formed kitty sequence
+  /// (1–4 parts, all-digits/':' in the numeric fields, valid
+  /// percent-encoded text in the 4th part if present).
+  bool _isValidKittyParts(List<String> parts) {
+    if (parts.isEmpty || parts.length > 4) return false;
+    for (var i = 0; i < parts.length && i <= 2; i++) {
+      if (!_isDigitsAndColons(parts[i])) return false;
+    }
+    if (parts.length == 4 && !_isValidAssociatedText(parts[3])) {
+      return false;
+    }
+    return true;
+  }
+
+  bool _isDigitsAndColons(String s) {
+    for (var i = 0; i < s.length; i++) {
+      final c = s.codeUnitAt(i);
+      if (c != 0x3A && (c < 0x30 || c > 0x39)) return false;
+    }
+    return true;
+  }
+
+  bool _isValidAssociatedText(String s) {
+    var i = 0;
+    while (i < s.length) {
+      final c = s.codeUnitAt(i);
+      if (c == 0x25) {
+        // '%' must be followed by exactly two hex digits.
+        if (i + 2 >= s.length) return false;
+        if (int.tryParse(s.substring(i + 1, i + 3), radix: 16) == null) {
+          return false;
+        }
+        i += 3;
+        continue;
+      }
+      if (c == 0x3B) return false; // ';' would clash with the part separator
+      if (c < 0x20 || c > 0x7E) return false;
+      i++;
+    }
+    return true;
+  }
+
+  /// Decode percent-encoded UTF-8 to a Dart String. Non-ASCII
+  /// bytes must be encoded; ASCII printable chars are sent as-is.
+  String _decodePercentEncoded(String s) {
+    final bytes = <int>[];
+    var i = 0;
+    while (i < s.length) {
+      final ch = s[i];
+      if (ch == '%' && i + 2 < s.length) {
+        final byte = int.tryParse(s.substring(i + 1, i + 3), radix: 16);
+        if (byte != null) {
+          bytes.add(byte);
+          i += 3;
+          continue;
+        }
+      }
+      bytes.add(ch.codeUnitAt(0));
+      i++;
+    }
+    return utf8.decode(bytes, allowMalformed: true);
   }
 
   /// Parse xterm modifyOtherKeys sequence: CSI 27 ; modifier ; charcode ~
@@ -899,7 +977,11 @@ class InputParser {
 
   /// Convert a Unicode codepoint to a KeyboardEvent with the given modifiers.
   KeyboardEvent _codepointToKeyEvent(int codepoint, ModifierKeys modifiers) {
-    // Map well-known codepoints to LogicalKeys
+    // Map well-known codepoints to LogicalKeys. The full table
+    // lives in [_logicalKeyForCodepoint] (shared with the 4-part
+    // kitty handler); here we only need the subset whose
+    // KeyboardEvent also carries a `character` (Enter/Tab) or
+    // carries no character (Escape/Backspace).
     switch (codepoint) {
       case 13: // Enter/Return
         return KeyboardEvent(
@@ -933,6 +1015,38 @@ class InputParser {
           character: char,
           modifiers: modifiers,
         );
+    }
+  }
+
+  /// Map a codepoint to its [LogicalKey]. Shared by
+  /// [_codepointToKeyEvent] and the 4-part kitty handler (where
+  /// the character comes from the associated text).
+  LogicalKey _logicalKeyForCodepoint(int codepoint) {
+    switch (codepoint) {
+      case 13: // Enter/Return
+        return LogicalKey.enter;
+      case 9: // Tab
+        return LogicalKey.tab;
+      case 27: // Escape
+        return LogicalKey.escape;
+      case 127: // Backspace
+        return LogicalKey.backspace;
+      case 1: // modifyOtherKeys: Home
+        return LogicalKey.home;
+      case 2: // modifyOtherKeys: Insert
+        return LogicalKey.insert;
+      case 3: // modifyOtherKeys: Delete
+        return LogicalKey.delete;
+      case 4: // modifyOtherKeys: End
+        return LogicalKey.end;
+      case 5: // modifyOtherKeys: PageUp
+        return LogicalKey.pageUp;
+      case 6: // modifyOtherKeys: PageDown
+        return LogicalKey.pageDown;
+      default:
+        final char = String.fromCharCode(codepoint);
+        return LogicalKey.fromCharacter(char) ??
+            LogicalKey(codepoint, 'codepoint($codepoint)');
     }
   }
 

--- a/lib/src/utils/escape_codes.dart
+++ b/lib/src/utils/escape_codes.dart
@@ -48,10 +48,11 @@ class _Enable {
   String get basicMouseTracking => '\x1B[?1000h';
   String get bracketedPasteMode => '\x1B[?2004h';
 
-  /// Push kitty keyboard mode with flags:
-  /// - Bit 0 (1): Disambiguate escape codes
-  /// This is sufficient for detecting Shift+Enter, Ctrl+Enter, etc.
-  String get kittyKeyboard => '\x1B[>1u';
+  /// Push kitty keyboard mode. Bit 0 (disambiguate escape codes)
+  /// + bit 4 (report associated text, so IME commits on
+  /// supporting terminals arrive as 4-part key events instead of
+  /// being routed through bracketed paste).
+  String get kittyKeyboard => '\x1B[>17u';
 
   /// Enable xterm modifyOtherKeys mode (level 1).
   String get modifyOtherKeys => '\x1B[>4;1m';

--- a/test/components/text_field_clipboard_test.dart
+++ b/test/components/text_field_clipboard_test.dart
@@ -273,5 +273,176 @@ void main() {
         },
       );
     });
+
+    // Framework exposes TerminalBinding.consumePendingPasteText so
+    // bracketed-paste payloads (and the Warp-style batched-character
+    // fallback) can be inserted without going through
+    // ClipboardManager.copy — important on macOS, where IME-committed
+    // text arrives as bracketed-paste and would otherwise overwrite
+    // the user's clipboard.
+    group('framework-stashed paste text (IME / bracketed paste)', () {
+      test('pending text is consumed by Ctrl+V in the focused TextField',
+          () async {
+        await testNocterm(
+          'pending paste text IME path',
+          (tester) async {
+            final controller = TextEditingController(text: '');
+
+            await tester.pumpComponent(
+              TextField(
+                controller: controller,
+                focused: true,
+                decoration: InputDecoration(
+                  border: BoxBorder.all(),
+                ),
+              ),
+            );
+
+            // Simulate the framework stashing a paste payload
+            // (this is what `TerminalBinding` does on a
+            // `PasteInputEvent`).
+            NoctermBinding.instance
+                .setPendingPasteTextForTest('你好世界');
+
+            // The system clipboard is empty — the IME text must
+            // NOT have been written there.
+            expect(ClipboardManager.paste(), isNull);
+
+            // Ctrl+V is then routed by the framework, just like
+            // for a real paste. The TextField should pull the
+            // pending text and insert it.
+            await tester.sendKeyEvent(KeyboardEvent(
+              logicalKey: LogicalKey.keyV,
+              modifiers: const ModifierKeys(ctrl: true),
+            ));
+            await tester.pump();
+
+            expect(controller.text, equals('你好世界'));
+            // The system clipboard is still untouched.
+            expect(ClipboardManager.paste(), isNull);
+          },
+        );
+      });
+
+      test('pending text wins over a stale system clipboard', () async {
+        await testNocterm(
+          'pending paste text wins over clipboard',
+          (tester) async {
+            final controller = TextEditingController(text: '');
+
+            // Stale clipboard content the user copied earlier
+            // (a real Ctrl+C). It must NOT leak into the IME
+            // paste path.
+            ClipboardManager.copy('stale clipboard content');
+
+            await tester.pumpComponent(
+              TextField(
+                controller: controller,
+                focused: true,
+                decoration: InputDecoration(
+                  border: BoxBorder.all(),
+                ),
+              ),
+            );
+
+            // Framework stashes the IME text...
+            NoctermBinding.instance.setPendingPasteTextForTest('tool');
+            // ...Ctrl+V arrives...
+            await tester.sendKeyEvent(KeyboardEvent(
+              logicalKey: LogicalKey.keyV,
+              modifiers: const ModifierKeys(ctrl: true),
+            ));
+            await tester.pump();
+
+            // ...the pending text is inserted (not the stale
+            // clipboard).
+            expect(controller.text, equals('tool'));
+          },
+        );
+      });
+
+      test('real Ctrl+V still reads from the system clipboard', () async {
+        await testNocterm(
+          'real Ctrl+V falls through to clipboard',
+          (tester) async {
+            final controller = TextEditingController(text: '');
+
+            // No pending text was stashed — the framework only
+            // sets it for bracketed-paste / batched-character
+            // events, not for real key presses.
+
+            // The user previously copied something to the
+            // clipboard.
+            ClipboardManager.copy('from clipboard');
+
+            await tester.pumpComponent(
+              TextField(
+                controller: controller,
+                focused: true,
+                decoration: InputDecoration(
+                  border: BoxBorder.all(),
+                ),
+              ),
+            );
+
+            await tester.sendKeyEvent(KeyboardEvent(
+              logicalKey: LogicalKey.keyV,
+              modifiers: const ModifierKeys(ctrl: true),
+            ));
+            await tester.pump();
+
+            // The clipboard text wins when no pending text is
+            // set, preserving the previous behaviour for real
+            // user-initiated paste.
+            expect(controller.text, equals('from clipboard'));
+          },
+        );
+      });
+
+      test(
+          'pending text is cleared if no widget consumes it (no leak '
+          'to a subsequent real Ctrl+V)', () async {
+        await testNocterm(
+          'pending text cleared after routing',
+          (tester) async {
+            final controller = TextEditingController(text: '');
+
+            await tester.pumpComponent(
+              TextField(
+                controller: controller,
+                focused: true,
+                decoration: InputDecoration(
+                  border: BoxBorder.all(),
+                ),
+              ),
+            );
+
+            // First batch: framework stashes IME text, Ctrl+V is
+            // routed, TextField consumes and inserts.
+            NoctermBinding.instance.setPendingPasteTextForTest('你好');
+            await tester.sendKeyEvent(KeyboardEvent(
+              logicalKey: LogicalKey.keyV,
+              modifiers: const ModifierKeys(ctrl: true),
+            ));
+            await tester.pump();
+            expect(controller.text, equals('你好'));
+            expect(NoctermBinding.instance.consumePendingPasteText(), isNull,
+                reason: 'slot must be empty after consumption');
+
+            // Now the user explicitly copies something to the
+            // clipboard and presses Ctrl+V for real. The stale
+            // IME text must NOT reappear.
+            controller.text = '';
+            ClipboardManager.copy('explicit copy');
+            await tester.sendKeyEvent(KeyboardEvent(
+              logicalKey: LogicalKey.keyV,
+              modifiers: const ModifierKeys(ctrl: true),
+            ));
+            await tester.pump();
+            expect(controller.text, equals('explicit copy'));
+          },
+        );
+      });
+    });
   });
 }

--- a/test/input/kitty_associated_text_test.dart
+++ b/test/input/kitty_associated_text_test.dart
@@ -1,0 +1,222 @@
+import 'package:nocterm/src/keyboard/input_event.dart';
+import 'package:nocterm/src/keyboard/input_parser.dart';
+import 'package:nocterm/src/keyboard/logical_key.dart';
+import 'package:test/test.dart';
+
+/// Tests for the 4-part form of the Kitty keyboard protocol
+/// (`CSI codepoint ; modifiers ; base ; text u`), used by
+/// terminals to surface IME-committed text. The 4th part is
+/// percent-encoded UTF-8 (so "你好" arrives as
+/// `%E4%BD%A0%E5%A5%BD`).
+///
+/// 2- and 3-part forms (the only ones supported before this
+/// work) are regression-tested at the bottom.
+void main() {
+  group('InputParser — Kitty 4-part form (associated text)', () {
+    late InputParser parser;
+
+    setUp(() {
+      parser = InputParser();
+    });
+
+    test('4-part: ASCII associated text becomes the character', () {
+      // ESC [ 1 1 6 ; 1 ; 1 ; t o o l u
+      //   codepoint 116 = 't', no modifiers, base layout 1, text "tool"
+      // Realistic Chinese-IME shape: user typed "tool" pinyin,
+      // confirmed candidate, terminal emits this kitty sequence.
+      parser.addBytes('\x1B[116;1;1;tool u'.codeUnits);
+      final event = parser.parseNext();
+      expect(event, isA<KeyboardInputEvent>(),
+          reason: 'must be a KeyboardInputEvent — NOT a PasteInputEvent. '
+              'If it were a PasteInputEvent, the IME text would be '
+              'routed through the paste path and could be misread '
+              'as a file drop (e.g. "tool" → [directory: .../tool]).');
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.character, 'tool');
+    });
+
+    test('4-part: CJK associated text is percent-decoded to a Dart '
+        'String', () {
+      // Per the Kitty spec, the associated text is percent-encoded
+      // UTF-8, so the IME output "你好" arrives as
+      // "%E4%BD%A0%E5%A5%BD" (one byte becomes three chars). The
+      // codepoint 20320 (0x4F60) is the base layout key for '你'
+      // on a US keyboard — the IME replaces the character with its
+      // own output, which is what must reach the focused widget.
+      parser.addBytes('\x1B[20320;1;1;%E4%BD%A0%E5%A5%BD u'.codeUnits);
+      final event = parser.parseNext();
+      expect(event, isA<KeyboardInputEvent>());
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.character, '你好');
+    });
+
+    test('4-part: percent-encoded special chars (space)', () {
+      // "hello world" — the space is percent-encoded as %20 per
+      // the Kitty spec.
+      parser.addBytes('\x1B[116;1;1;hello%20world u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.character, 'hello world');
+    });
+
+    test('4-part: percent-encoded UTF-8 CJK bytes', () {
+      // "你好" UTF-8 = E4 BD A0 E5 A5 BD → percent-encoded.
+      // The terminal always percent-encodes non-ASCII bytes per
+      // spec, so the parser must decode them back to a Dart
+      // String (interpreted as UTF-8).
+      parser.addBytes('\x1B[116;1;1;%E4%BD%A0%E5%A5%BD u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.character, '你好');
+    });
+
+    test('4-part: Shift modifier is preserved alongside the text', () {
+      // mod 2 = shift (1 + bitmask 1). Associated text is the
+      // capitalised form; the TextField uses `character` to
+      // insert, so the capitalisation is what the user sees.
+      parser.addBytes('\x1B[116;2;1;Tool u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.character, 'Tool');
+      expect(keyEvent.modifiers.shift, isTrue);
+      expect(keyEvent.modifiers.ctrl, isFalse);
+    });
+
+    test('4-part: codepoint still drives logicalKey', () {
+      // codepoint 13 = Enter. An IME commit that happens to be on
+      // the Enter key (e.g. confirming a candidate with Enter on
+      // a Japanese IME) should still report the Enter logical key
+      // so any focused widget's `onKeyEvent` sees a regular
+      // Enter, not a text insertion.
+      parser.addBytes('\x1B[13;1;1;enter u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.logicalKey, LogicalKey.enter);
+      expect(keyEvent.character, 'enter');
+    });
+
+    test('4-part: empty associated text falls back to codepoint '
+        'character', () {
+      // Some terminals may send an empty 4th part instead of
+      // dropping to the 3-part form. Treat it as "no text" and
+      // fall back to the codepoint-derived character.
+      parser.addBytes('\x1B[116;1;1; u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.character, 't',
+          reason: 'empty associated text → use codepoint character');
+    });
+
+    test('4-part: two sequences back-to-back parse independently', () {
+      // Simulates a user confirming two IME candidates quickly:
+      // "tool" then "foo". Each emits its own 4-part sequence;
+      // the parser must yield two independent KeyboardInputEvents.
+      parser.addBytes('\x1B[116;1;1;tool u\x1B[97;1;1;foo u'.codeUnits);
+      final chars = <String>[];
+      InputEvent? event;
+      while ((event = parser.parseNext()) != null) {
+        if (event is KeyboardInputEvent) {
+          chars.add(event.event.character ?? '');
+        }
+      }
+      expect(chars, ['tool', 'foo']);
+    });
+
+    test('4-part: sequence with sub-parameters in codepoint', () {
+      // "report alternate keys" mode uses colon sub-parameters.
+      // 13:10 means "Enter with numpad layout". The associated
+      // text path must not break on these.
+      parser.addBytes('\x1B[13:10;1;1;enter u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.logicalKey, LogicalKey.enter);
+      expect(keyEvent.character, 'enter');
+    });
+
+    test('regression: 2-part form (just codepoint) still works', () {
+      parser.addBytes('\x1B[13u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.logicalKey, LogicalKey.enter);
+    });
+
+    test('regression: 3-part form (codepoint + modifiers) still works',
+        () {
+      parser.addBytes('\x1B[116;1u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.character, 't');
+      expect(keyEvent.modifiers.hasAnyModifier, isFalse);
+    });
+
+    test('regression: 3-part form with Ctrl modifier', () {
+      parser.addBytes('\x1B[97;5u'.codeUnits);
+      final event = parser.parseNext();
+      final keyEvent = (event! as KeyboardInputEvent).event;
+      expect(keyEvent.logicalKey, LogicalKey.keyA);
+      expect(keyEvent.modifiers.ctrl, isTrue);
+    });
+
+    test('5-part form: parser degrades to per-byte parsing instead '
+        'of treating it as a (broken) 4-part sequence', () {
+      // The Kitty spec defines 1-4 part sequences; 5+ is
+      // non-standard. The parser must not (a) hang on the input
+      // and (b) must NOT misinterpret it as a 4-part sequence
+      // that silently swallows the trailing "extra" into the
+      // associated text. The right behavior is to fail validation
+      // of the kitty sequence and fall through to the per-byte
+      // character parser, which is what non-kitty bytes do.
+      parser.addBytes('\x1B[116;1;1;text;extra u'.codeUnits);
+
+      // Drain the parser. The exact number of events is an
+      // implementation detail; the invariants we check are:
+      //   1) the parser makes progress (no hang),
+      //   2) no single KeyboardInputEvent carries a multi-char
+      //      `character` (which would mean a broken 4-part
+      //      interpretation produced a huge associated-text blob).
+      final charLengths = <int>[];
+      var progressed = false;
+      InputEvent? event;
+      while ((event = parser.parseNext()) != null) {
+        progressed = true;
+        if (event is KeyboardInputEvent && event.event.character != null) {
+          charLengths.add(event.event.character!.length);
+        }
+      }
+      expect(progressed, isTrue,
+          reason: 'parser must make progress and not hang on '
+              'malformed input');
+      expect(charLengths.every((n) => n <= 1), isTrue,
+          reason: 'no event should carry a multi-char `character` '
+              '— that would mean a 4-part interpretation snuck '
+              'through. Got char lengths: $charLengths');
+    });
+
+    test('regression: bracketed paste in the same stream still '
+        'parses independently', () {
+      // A realistic mixed stream: a file drop (bracketed paste)
+      // followed by an IME commit (4-part kitty).
+      final bytes = <int>[
+        ...'\x1B[200~'.codeUnits,
+        ...'/Users/me/notes.md'.codeUnits,
+        ...'\x1B[201~'.codeUnits,
+        ...'\x1B[116;1;1;tool u'.codeUnits,
+      ];
+      parser.addBytes(bytes);
+
+      final events = <String>[];
+      InputEvent? event;
+      while ((event = parser.parseNext()) != null) {
+        if (event is PasteInputEvent) {
+          events.add('paste:${event.text}');
+        } else if (event is KeyboardInputEvent) {
+          events.add('key:${event.event.character}');
+        }
+      }
+      expect(events, [
+        'paste:/Users/me/notes.md',
+        'key:tool',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
Two related fixes for the IME (Chinese / Japanese / Korean input
method editor) text path on macOS and Linux.

## 1. Paste path no longer pollutes the system clipboard

On macOS, the Chinese / Japanese / Korean IMEs wrap their
committed candidate text in bracketed-paste markers
(`ESC[200~ ... ESC[201~`), so a confirmed word like `tool` or
`你好` arrives at the framework as a `PasteInputEvent`.
Previously `TerminalBinding` called `ClipboardManager.copy` on
the payload and then routed a synthetic Ctrl+V so
`TextField._paste` could read it back from the clipboard. This
worked for real paste, but on the IME path it overwrote
whatever the user had on their system clipboard every single
time they confirmed a candidate.

The framework now stashes the paste text on the binding
(`NoctermBinding.setPendingPasteText`) and `TextField._paste`
consumes it via
`NoctermBinding.instance.consumePendingPasteText` at the top
of its paste path. Real user-initiated Ctrl+V has no pending
text and still reads from the system clipboard as before. The
system clipboard is no longer touched on the IME path.

## 2. Kitty keyboard protocol: 4-part form (associated text)

When the terminal supports the Kitty keyboard protocol's "report
associated text" flag (iTerm2, WezTerm, Ghostty, Kitty), IME
commits now arrive as ordinary key events with the IME's output
in the `character` field, instead of being routed through
bracketed-paste mode at all. Format:

    CSI codepoint ; modifiers ; base_layout ; text u

where `text` is percent-encoded UTF-8 (so `你好` arrives as
`%E4%BD%A0%E5%A5%BD`). The framework now requests this flag at
startup (`ESC[>17u` — bit 0 disambiguate + bit 4 associated
text) and the input parser recognizes the 4-part form. The
affected `_parseKittySequence` uses a backward-then-validate scan
to disambiguate the terminator `u` from `u` bytes that may
appear un-percent-encoded inside the associated text (`u` is
unreserved in URL encoding, so e.g. `menu` is sent verbatim,
not as `men%75`).

The benefit on supporting terminals is twofold: (a) IME text
reaches the focused widget as a regular `KeyboardInputEvent`,
not a `PasteInputEvent`, so it is no longer misrouted through
any app-level paste handling (e.g. file-drop detectors); (b)
the system clipboard is never touched on the IME path (even
the binding-level stash is bypassed). On terminals without
this flag, IME commits still fall through to the bracketed-paste
path and benefit from fix #1.

A small refactor extracts `_logicalKeyForCodepoint` from
`_codepointToKeyEvent` so the codepoint → LogicalKey mapping
is shared between the 1–3 part form (character derived from
codepoint) and the 4-part form (character from associated
text, logical key from codepoint).

## Tests

- 4 new tests in `text_field_clipboard_test.dart` cover the
  pending-paste-text mechanism (IME path, fallthrough to
  clipboard, real Ctrl+V, no-leak to subsequent Ctrl+V).
- 14 new tests in `kitty_associated_text_test.dart` cover the
  4-part form (ASCII text, CJK text, percent-encoding,
  sub-parameters, codepoint driving `logicalKey`, two
  sequences back-to-back, 5-part rejection, mixed
  bracketed-paste + kitty stream, 2-/3-part regression).
