### PR TITLE
feat: Export TerminalCanvas, BorderStyle, and AsciiLayoutEngine

### DIFF
--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -15,7 +15,6 @@ import 'dart:math' as math;
 
 import 'package:characters/characters.dart';
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:nocterm/src/utils/unicode_width.dart';
 
 // ---------------------------------------------------------------------------

--- a/lib/nocterm.dart
+++ b/lib/nocterm.dart
@@ -35,6 +35,7 @@ export 'src/components/terminal_xterm.dart';
 export 'nocterm_test.dart';
 export 'src/framework/framework.dart';
 export 'src/framework/axis.dart';
+export 'src/framework/terminal_canvas.dart' show TerminalCanvas, BorderStyle;
 
 export 'src/components/spacer.dart';
 export 'src/components/divider.dart';

--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:nocterm/src/navigation/render_theater.dart';
 import 'package:nocterm/src/rendering/scrollable_render_object.dart';
 import 'package:nocterm/src/image/image_cleanup.dart';

--- a/lib/src/components/ascii_text.dart
+++ b/lib/src/components/ascii_text.dart
@@ -5,7 +5,8 @@ import 'render_text.dart' show TextAlign;
 
 // Re-export for convenience
 export 'ascii_font.dart' show AsciiFont, AsciiGlyph;
-export 'render_ascii_text.dart' show AsciiLayoutConfig, AsciiLayoutResult;
+export 'render_ascii_text.dart'
+    show AsciiLayoutConfig, AsciiLayoutResult, AsciiLayoutEngine;
 
 /// A component that displays text as ASCII art using customizable fonts.
 ///

--- a/lib/src/components/basic.dart
+++ b/lib/src/components/basic.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart' hide TextAlign;
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 import 'render_text.dart';
 

--- a/lib/src/components/clip.dart
+++ b/lib/src/components/clip.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 /// A widget that clips its child using a rectangle.
 ///

--- a/lib/src/components/decorated_box.dart
+++ b/lib/src/components/decorated_box.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 /// Title alignment options for border titles
 enum TitleAlignment {

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 enum DividerStyle {
   single,

--- a/lib/src/components/error_widget.dart
+++ b/lib/src/components/error_widget.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 /// A widget that displays an error message when a render object fails.
 ///

--- a/lib/src/components/image.dart
+++ b/lib/src/components/image.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 import 'package:meta/meta.dart';
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:nocterm/src/image/color_quantizer.dart';
 import 'package:nocterm/src/image/image_cleanup.dart';
 import 'package:nocterm/src/image/iterm2_encoder.dart';

--- a/lib/src/components/list_view.dart
+++ b/lib/src/components/list_view.dart
@@ -1,7 +1,6 @@
 import 'dart:math' as math;
 
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 import '../rendering/scrollable_render_object.dart';
 import 'selection_state.dart';

--- a/lib/src/components/modal_barrier.dart
+++ b/lib/src/components/modal_barrier.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart';
-import '../framework/terminal_canvas.dart';
 
 /// Applies a color tint over its child content.
 ///

--- a/lib/src/components/progress_bar.dart
+++ b/lib/src/components/progress_bar.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 enum ProgressBarBorderStyle {
   single,

--- a/lib/src/components/render_ascii_text.dart
+++ b/lib/src/components/render_ascii_text.dart
@@ -1,6 +1,5 @@
 import 'package:characters/characters.dart';
 import 'package:nocterm/nocterm.dart' hide TextAlign;
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:nocterm/src/utils/unicode_width.dart';
 
 import 'render_text.dart' show TextAlign;

--- a/lib/src/components/render_flex.dart
+++ b/lib/src/components/render_flex.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 /// Render object for flex layouts (Row/Column)
 class RenderFlex extends RenderObject

--- a/lib/src/components/render_paragraph.dart
+++ b/lib/src/components/render_paragraph.dart
@@ -1,6 +1,5 @@
 import 'package:characters/characters.dart';
 import 'package:nocterm/nocterm.dart' hide TextAlign;
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 import '../text/text_layout_engine.dart';
 import '../utils/unicode_width.dart';

--- a/lib/src/components/render_stack.dart
+++ b/lib/src/components/render_stack.dart
@@ -1,7 +1,6 @@
 import 'dart:math' as math;
 
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'stack.dart' as stack_lib;
 
 /// Implements the stack layout algorithm.

--- a/lib/src/components/render_text.dart
+++ b/lib/src/components/render_text.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart' hide TextAlign;
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 import '../text/text_layout_engine.dart';
 

--- a/lib/src/components/scrollbar.dart
+++ b/lib/src/components/scrollbar.dart
@@ -1,7 +1,6 @@
 import 'dart:math' as math;
 
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 /// A scrollbar that can be optionally shown for scrollable widgets.
 ///

--- a/lib/src/components/selectable.dart
+++ b/lib/src/components/selectable.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart' hide TextAlign;
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 import '../text/text_layout_engine.dart';
 import '../text/selection_utils.dart' as selection_utils;

--- a/lib/src/components/single_child_scroll_view.dart
+++ b/lib/src/components/single_child_scroll_view.dart
@@ -1,7 +1,6 @@
 import 'dart:math' as math;
 
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import '../rendering/scrollable_render_object.dart';
 
 /// A box in which a single widget can be scrolled.

--- a/lib/src/components/text_field.dart
+++ b/lib/src/components/text_field.dart
@@ -3,7 +3,6 @@ import 'dart:math' as math;
 
 import 'package:characters/characters.dart';
 import 'package:nocterm/nocterm.dart' hide TextAlign;
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import '../rendering/mouse_hit_test.dart';
 import '../rendering/mouse_tracker.dart';
 import '../text/text_layout_engine.dart';

--- a/lib/src/navigation/render_theater.dart
+++ b/lib/src/navigation/render_theater.dart
@@ -1,7 +1,6 @@
 import 'dart:collection';
 
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:nocterm/src/components/stack.dart' as stack_lib;
 
 /// Parent data for children in a RenderTheater.

--- a/lib/src/test/nocterm_test_binding.dart
+++ b/lib/src/test/nocterm_test_binding.dart
@@ -194,7 +194,9 @@ class NoctermTestBinding extends NoctermBinding with SchedulerBinding {
   /// Shutdown the test binding
   void shutdown() {
     _testKeyboardController.close();
-    // Clear the singleton instance to allow multiple tests
+    // Clear the singleton so tests can create fresh bindings; the analyzer cannot
+    // tell this lib/ file is test-only.
+    // ignore: invalid_use_of_visible_for_testing_member
     NoctermBinding.resetInstance();
     _instance = null;
   }

--- a/lib/src/test/nocterm_test_binding.dart
+++ b/lib/src/test/nocterm_test_binding.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:nocterm/src/rendering/mouse_hit_test.dart';
 import 'package:nocterm/src/rendering/mouse_tracker.dart';
 

--- a/lib/src/text/selection_utils.dart
+++ b/lib/src/text/selection_utils.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 
 import 'package:characters/characters.dart';
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 
 import '../utils/unicode_width.dart';
 

--- a/test/foundation/error_recovery_test.dart
+++ b/test/foundation/error_recovery_test.dart
@@ -1,6 +1,5 @@
 import 'package:nocterm/nocterm.dart';
 import 'package:nocterm/src/components/error_widget.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/framework/render_pipeline_test.dart
+++ b/test/framework/render_pipeline_test.dart
@@ -1,5 +1,4 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:nocterm/src/framework/terminal_canvas.dart';
 import 'package:test/test.dart';
 
 /// Comprehensive test suite for the nocterm rendering pipeline.


### PR DESCRIPTION
Adds three already public by association symbols to nocterm's public API:

- `TerminalCanvas` and `BorderStyle` (`lib/nocterm.dart`)
- `AsciiLayoutEngine` (`lib/src/components/ascii_text.dart`, next to the existing `AsciiLayoutConfig` / `AsciiLayoutResult` exports)

These types are already part of nocterm's public surface but weren't exported:

Downstream packages that use these have to via `import 'package:nocterm/src/...'` with `// ignore: implementation_imports`.

This is mainly to get Copilot to stop complaining about this on our PR's 😅 