### PR TITLE
feat: Merge box-drawing lines into junctions where they meet

### DIFF
--- a/example/box_line_blending_demo.dart
+++ b/example/box_line_blending_demo.dart
@@ -107,27 +107,62 @@ class _DemoPane extends StatelessComponent {
         ),
         SizedBox(height: 1),
         // Scenario 1: split panes - a vertical divider and a horizontal
-        // header rule inside one bordered box.
+        // header rule inside one bordered box, in two different styles.
+        //
+        // The dashed rule tees into the light border as a solid `├`: dashed
+        // and dotted variants carry the same arms as their solid
+        // counterparts, so a junction never comes out dashed. Where it runs
+        // into the double divider it forms `╢`, and the double divider tees
+        // into the light border above and below as `╥` and `╨`.
+        //
+        // The divider is a layer of its own, painted before the content, so
+        // that the horizontal rule has something to join when it arrives.
+        // Blending only sees what is already in the buffer: a junction
+        // needs the surface drawn first, exactly as the box's own border is
+        // drawn before the dividers that tee into it. As Row siblings the
+        // vertical divider would paint second and the rule would simply
+        // stop against it.
         Expanded(
           child: Container(
             decoration: BoxDecoration(
               border: BoxBorder.all(style: BoxBorderStyle.rounded),
               title: BorderTitle(text: 'Split panes'),
             ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
+            child: Stack(
               children: [
-                Expanded(
-                  child: Column(
-                    children: [
-                      Center(child: Text('Server')),
-                      Divider(indent: indent, endIndent: indent),
-                      Expanded(child: Center(child: Text('logs'))),
-                    ],
-                  ),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(child: SizedBox.shrink()),
+                    VerticalDivider(
+                      indent: indent,
+                      endIndent: indent,
+                      style: DividerStyle.double,
+                    ),
+                    Expanded(child: SizedBox.shrink()),
+                  ],
                 ),
-                VerticalDivider(indent: indent, endIndent: indent),
-                Expanded(child: Center(child: Text('Apps'))),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        children: [
+                          Center(child: Text('Server')),
+                          Divider(
+                            indent: indent,
+                            endIndent: indent,
+                            style: DividerStyle.dashed,
+                          ),
+                          Expanded(child: Center(child: Text('logs'))),
+                        ],
+                      ),
+                    ),
+                    // Where the divider already is.
+                    SizedBox(width: 1),
+                    Expanded(child: Center(child: Text('Apps'))),
+                  ],
+                ),
               ],
             ),
           ),
@@ -135,10 +170,15 @@ class _DemoPane extends StatelessComponent {
         SizedBox(height: 1),
         // Scenario 2: crossing dividers meeting in a cross junction, plus
         // a heavy divider showing mixed-weight tees.
+        //
+        // The border is heavy here, so the light dividers reaching into it
+        // tee as `┠`/`┨` and `┰`/`┸` - the wall stays heavy and the arm
+        // stays light rather than either weight winning. The heavy divider
+        // meets it as `┣`/`┫`, all of one weight.
         Expanded(
           child: Container(
             decoration: BoxDecoration(
-              border: BoxBorder.all(style: BoxBorderStyle.rounded),
+              border: BoxBorder.all(style: BoxBorderStyle.bold),
               title: BorderTitle(text: 'Crossing + heavy'),
             ),
             child: Stack(

--- a/example/box_line_blending_demo.dart
+++ b/example/box_line_blending_demo.dart
@@ -1,0 +1,181 @@
+import 'package:nocterm/nocterm.dart';
+
+/// Demonstrates box-line blending: dividers and overlaid borders merge with
+/// the box-drawing characters underneath them, forming junctions
+/// (`├ ┤ ┬ ┴ ┼`) instead of leaving gaps.
+///
+/// Dividers join a surrounding border by reaching into it with negative
+/// indents. The left column keeps dividers inside their own bounds
+/// (`indent: 0`, lines stop short of the border), the right column reaches
+/// into the border rows and columns (`indent: -1`, junctions form) - same
+/// layout otherwise.
+class BoxLineBlendingDemo extends StatelessComponent {
+  const BoxLineBlendingDemo({super.key});
+
+  @override
+  Component build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(1),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Box-Line Blending Demo',
+            style: TextStyle(
+                color: Colors.cyan, decoration: TextDecoration.underline),
+          ),
+          SizedBox(height: 1),
+          Text(
+            'Left: indent: 0 (dividers stop short of the border) · '
+            'Right: indent: -1 (junctions)',
+            style: TextStyle(color: Colors.grey),
+          ),
+          SizedBox(height: 1),
+          Expanded(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(child: _DemoPane(reachIntoBorders: false)),
+                SizedBox(width: 2),
+                Expanded(child: _DemoPane(reachIntoBorders: true)),
+              ],
+            ),
+          ),
+          SizedBox(height: 1),
+          // The overlaid-panel case needs no indents at all: the panel's
+          // border corners always merge with the border they land on.
+          SizedBox(
+            height: 7,
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: BoxBorder.all(style: BoxBorderStyle.rounded),
+                      title: BorderTitle(
+                        text: 'Overlaid panel - corners tee into the border',
+                      ),
+                    ),
+                  ),
+                ),
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: SizedBox(
+                    width: 20,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        border: BoxBorder.all(style: BoxBorderStyle.rounded),
+                      ),
+                      child: Center(child: Text('Apps')),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(height: 1),
+          Text(
+            'Press Ctrl+C to exit',
+            style: TextStyle(color: Colors.grey),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One column of divider scenarios, with or without negative indents.
+class _DemoPane extends StatelessComponent {
+  const _DemoPane({required this.reachIntoBorders});
+
+  final bool reachIntoBorders;
+
+  @override
+  Component build(BuildContext context) {
+    final indent = reachIntoBorders ? -1.0 : 0.0;
+    final label = reachIntoBorders ? 'indent: -1' : 'indent: 0';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            color: reachIntoBorders ? Colors.green : Colors.red,
+          ),
+        ),
+        SizedBox(height: 1),
+        // Scenario 1: split panes - a vertical divider and a horizontal
+        // header rule inside one bordered box.
+        Expanded(
+          child: Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(style: BoxBorderStyle.rounded),
+              title: BorderTitle(text: 'Split panes'),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: Column(
+                    children: [
+                      Center(child: Text('Server')),
+                      Divider(indent: indent, endIndent: indent),
+                      Expanded(child: Center(child: Text('logs'))),
+                    ],
+                  ),
+                ),
+                VerticalDivider(indent: indent, endIndent: indent),
+                Expanded(child: Center(child: Text('Apps'))),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(height: 1),
+        // Scenario 2: crossing dividers meeting in a cross junction, plus
+        // a heavy divider showing mixed-weight tees.
+        Expanded(
+          child: Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(style: BoxBorderStyle.rounded),
+              title: BorderTitle(text: 'Crossing + heavy'),
+            ),
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  child: Column(
+                    children: [
+                      Expanded(child: SizedBox.shrink()),
+                      Divider(indent: indent, endIndent: indent),
+                      Expanded(child: SizedBox.shrink()),
+                      Divider(
+                        indent: indent,
+                        endIndent: indent,
+                        style: DividerStyle.bold,
+                      ),
+                      Expanded(child: SizedBox.shrink()),
+                    ],
+                  ),
+                ),
+                Positioned.fill(
+                  child: Row(
+                    children: [
+                      Expanded(child: SizedBox.shrink()),
+                      VerticalDivider(indent: indent, endIndent: indent),
+                      Expanded(child: SizedBox.shrink()),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+void main() {
+  runApp(const BoxLineBlendingDemo());
+}

--- a/example/box_line_blending_demo.dart
+++ b/example/box_line_blending_demo.dart
@@ -42,40 +42,6 @@ class BoxLineBlendingDemo extends StatelessComponent {
             ),
           ),
           SizedBox(height: 1),
-          // The overlaid-panel case needs no indents at all: the panel's
-          // border corners always merge with the border they land on.
-          SizedBox(
-            height: 7,
-            child: Stack(
-              children: [
-                Positioned.fill(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      border: BoxBorder.all(style: BoxBorderStyle.rounded),
-                      title: BorderTitle(
-                        text: 'Overlaid panel - corners tee into the border',
-                      ),
-                    ),
-                  ),
-                ),
-                Positioned(
-                  top: 0,
-                  right: 0,
-                  bottom: 0,
-                  child: SizedBox(
-                    width: 20,
-                    child: Container(
-                      decoration: BoxDecoration(
-                        border: BoxBorder.all(style: BoxBorderStyle.rounded),
-                      ),
-                      child: Center(child: Text('Apps')),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          SizedBox(height: 1),
           Text(
             'Press Ctrl+C to exit',
             style: TextStyle(color: Colors.grey),
@@ -209,6 +175,56 @@ class _DemoPane extends StatelessComponent {
                 ),
               ],
             ),
+          ),
+        ),
+        SizedBox(height: 1),
+        // Scenario 3: a floating panel overlaid on the box.
+        //
+        // The panel carries a background, so it hides the text running
+        // underneath it - but its corners still tee into the border rather
+        // than staying `╭`/`╰`. Occlusion and blending are decided
+        // separately: the background fill stops short of the border ring so
+        // it cannot erase a border it is meant to merge with, and that ring
+        // is exactly where the corners fuse. Neither depends on the indent,
+        // so both columns render alike.
+        Expanded(
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: Container(
+                  decoration: BoxDecoration(
+                    border: BoxBorder.all(style: BoxBorderStyle.rounded),
+                    title: BorderTitle(text: 'Overlaid panel'),
+                  ),
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 1),
+                    child: Text(
+                      'This text sits behind the floating panel. Where the '
+                      'panel covers it, it simply disappears.',
+                      // Capped so a narrow terminal clips it rather than
+                      // letting it spill over the box's own bottom border.
+                      maxLines: 3,
+                      style: TextStyle(color: Colors.grey),
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                top: 0,
+                right: 0,
+                bottom: 0,
+                child: SizedBox(
+                  width: 12,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.black,
+                      border: BoxBorder.all(style: BoxBorderStyle.rounded),
+                    ),
+                    child: Center(child: Text('Apps')),
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ],

--- a/example/box_line_blending_demo.dart
+++ b/example/box_line_blending_demo.dart
@@ -178,7 +178,43 @@ class _DemoPane extends StatelessComponent {
           ),
         ),
         SizedBox(height: 1),
-        // Scenario 3: a floating panel overlaid on the box.
+        // Scenario 3: dividers reaching into the border row where the title
+        // sits. The title is fixed-length, so these columns are exact at
+        // any terminal width.
+        //
+        // A cap landing on a letter finds nothing it can join and leaves
+        // the cell alone, so the title survives. A cap landing on one of
+        // the title's spaces is a different matter: an empty cell takes the
+        // arm, because a line crossing it later has to find the arm waiting
+        // for it - and a space inside a title is empty as far as the buffer
+        // knows. So the two `╷` below, one in the gap after 'Divider' and
+        // one in the space closing the title, are the cost of the junction
+        // that the same rule buys elsewhere.
+        Expanded(
+          child: Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(style: BoxBorderStyle.rounded),
+              title: BorderTitle(text: 'Divider on a title'),
+            ),
+            child: Row(
+              children: [
+                // Column 5: the 'v' of 'Divider'. Left intact.
+                SizedBox(width: 4),
+                VerticalDivider(indent: indent, endIndent: indent),
+                // Column 10: the space between 'Divider' and 'on'.
+                SizedBox(width: 4),
+                VerticalDivider(indent: indent, endIndent: indent),
+                // Column 21: the space closing the title, just before the
+                // border run picks up again.
+                SizedBox(width: 10),
+                VerticalDivider(indent: indent, endIndent: indent),
+                Expanded(child: SizedBox.shrink()),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(height: 1),
+        // Scenario 4: a floating panel overlaid on the box.
         //
         // The panel carries a background, so it hides the text running
         // underneath it - but its corners still tee into the border rather

--- a/lib/nocterm.dart
+++ b/lib/nocterm.dart
@@ -74,6 +74,7 @@ export 'src/utils/log_server.dart';
 export 'src/utils/logger.dart';
 export 'src/utils/nocterm_paths.dart';
 export 'src/utils/escape_codes.dart';
+export 'src/utils/box_line_merging.dart';
 
 // Performance and Debugging
 export 'src/foundation/performance.dart';

--- a/lib/src/components/decorated_box.dart
+++ b/lib/src/components/decorated_box.dart
@@ -735,15 +735,18 @@ class RenderDecoratedBox extends RenderObject
       }
     }
 
+    // A vertical side stops short of the corners only where the top or
+    // bottom pass actually paints them. Without those borders it has to
+    // reach the end cell, which the inset fill does not cover either.
+    final verticalTop = top + (border.top.isNone ? 0 : 1);
+    final verticalBottom = bottom - (border.bottom.isNone ? 0 : 1);
+
     // Paint left border
     if (!border.left.isNone) {
       final style = TextStyle(
           color: border.left.color, backgroundColor: borderBackground);
-      // Only paint vertical lines if there's space between top and bottom
-      if (bottom > top) {
-        for (int y = top + 1; y < bottom; y++) {
-          _setCell(canvas, left, y, chars.vertical, style);
-        }
+      for (int y = verticalTop; y <= verticalBottom; y++) {
+        _setCell(canvas, left, y, chars.vertical, style);
       }
     }
 
@@ -751,11 +754,8 @@ class RenderDecoratedBox extends RenderObject
     if (!border.right.isNone && right > left) {
       final style = TextStyle(
           color: border.right.color, backgroundColor: borderBackground);
-      // Only paint vertical lines if there's space between top and bottom
-      if (bottom > top) {
-        for (int y = top + 1; y < bottom; y++) {
-          _setCell(canvas, right, y, chars.vertical, style);
-        }
+      for (int y = verticalTop; y <= verticalBottom; y++) {
+        _setCell(canvas, right, y, chars.vertical, style);
       }
     }
   }

--- a/lib/src/components/decorated_box.dart
+++ b/lib/src/components/decorated_box.dart
@@ -869,8 +869,8 @@ class _BorderCharacters {
   );
 
   static const dotted = _BorderCharacters(
-    horizontal: '┅',
-    vertical: '┇',
+    horizontal: '┄',
+    vertical: '┆',
     topLeft: '┌',
     topRight: '┐',
     bottomLeft: '└',

--- a/lib/src/components/decorated_box.dart
+++ b/lib/src/components/decorated_box.dart
@@ -586,7 +586,10 @@ class RenderDecoratedBox extends RenderObject
           // Minimum width: space + 1 char title + space + some border chars
           // Format: ─ Title ─────
           final titleText = title.plainText;
-          final titleStyle = title.style ?? borderStyle;
+          // The fill stops short of the border row, so a title style with
+          // no background of its own would show what was underneath.
+          final titleStyle = (title.style ?? borderStyle)
+              .copyWith(backgroundColor: borderBackground);
 
           // Calculate title display with " Title " format (space padding)
           // We need at least 2 horizontal chars for aesthetics

--- a/lib/src/components/decorated_box.dart
+++ b/lib/src/components/decorated_box.dart
@@ -110,7 +110,14 @@ enum BoxBorderStyle {
   rounded,
 }
 
-/// Box border configuration
+/// Box border configuration.
+///
+/// The border's corner cells merge with box-drawing characters already
+/// painted underneath them, forming junctions instead of overwriting them -
+/// e.g. an overlaid panel's corners landing on another box's border tee into
+/// it (`┬`/`┴`). Edge runs and title text always paint over what is
+/// underneath, so an overlaid panel still occludes unrelated content it
+/// covers.
 class BoxBorder {
   const BoxBorder({
     this.top = BorderSide.none,
@@ -490,7 +497,21 @@ class RenderDecoratedBox extends RenderObject
 
     // Paint background color
     if (_decoration.color != null) {
-      _paintBackground(canvas, absoluteRect, _decoration.color!);
+      var backgroundRect = absoluteRect;
+      final border = _decoration.border;
+      if (border != null && !border.hasNoBorder) {
+        // The border's corner cells merge with whatever is painted
+        // underneath them, so the background fill must not erase those
+        // cells first. The border pass paints the ring itself, using this
+        // background color.
+        backgroundRect = Rect.fromLTRB(
+          absoluteRect.left + (border.left.isNone ? 0 : 1),
+          absoluteRect.top + (border.top.isNone ? 0 : 1),
+          absoluteRect.right - (border.right.isNone ? 0 : 1),
+          absoluteRect.bottom - (border.bottom.isNone ? 0 : 1),
+        );
+      }
+      _paintBackground(canvas, backgroundRect, _decoration.color!);
     }
 
     // Paint border - pass the offset for absolute positioning
@@ -506,12 +527,14 @@ class RenderDecoratedBox extends RenderObject
   }
 
   void _setCell(
-      TerminalCanvas canvas, int x, int y, String char, TextStyle style) {
+      TerminalCanvas canvas, int x, int y, String char, TextStyle style,
+      {bool blend = false}) {
     // Use drawText with a single character at the given position
     canvas.drawText(
       Offset(x.toDouble(), y.toDouble()),
       char,
       style: style,
+      blendBoxLines: blend,
     );
   }
 
@@ -547,12 +570,12 @@ class RenderDecoratedBox extends RenderObject
         } else {
           charToUse = chars.horizontal;
         }
-        _setCell(canvas, left, top, charToUse, borderStyle);
+        _setCell(canvas, left, top, charToUse, borderStyle, blend: true);
       } else {
         // Use corner only if left border connects, otherwise use horizontal
         final leftTopChar =
             !border.left.isNone ? chars.topLeft : chars.horizontal;
-        _setCell(canvas, left, top, leftTopChar, borderStyle);
+        _setCell(canvas, left, top, leftTopChar, borderStyle, blend: true);
 
         // Check if we have a title to render
         final title = _decoration.title;
@@ -670,7 +693,7 @@ class RenderDecoratedBox extends RenderObject
         // Use corner only if right border connects, otherwise use horizontal
         final rightTopChar =
             !border.right.isNone ? chars.topRight : chars.horizontal;
-        _setCell(canvas, right, top, rightTopChar, borderStyle);
+        _setCell(canvas, right, top, rightTopChar, borderStyle, blend: true);
       }
     }
 
@@ -693,19 +716,19 @@ class RenderDecoratedBox extends RenderObject
         } else {
           charToUse = chars.horizontal;
         }
-        _setCell(canvas, left, bottom, charToUse, style);
+        _setCell(canvas, left, bottom, charToUse, style, blend: true);
       } else {
         // Use corner only if left border connects, otherwise use horizontal
         final leftBottomChar =
             !border.left.isNone ? chars.bottomLeft : chars.horizontal;
-        _setCell(canvas, left, bottom, leftBottomChar, style);
+        _setCell(canvas, left, bottom, leftBottomChar, style, blend: true);
         for (int x = left + 1; x < right; x++) {
           _setCell(canvas, x, bottom, chars.horizontal, style);
         }
         // Use corner only if right border connects, otherwise use horizontal
         final rightBottomChar =
             !border.right.isNone ? chars.bottomRight : chars.horizontal;
-        _setCell(canvas, right, bottom, rightBottomChar, style);
+        _setCell(canvas, right, bottom, rightBottomChar, style, blend: true);
       }
     }
 

--- a/lib/src/components/decorated_box.dart
+++ b/lib/src/components/decorated_box.dart
@@ -108,6 +108,7 @@ enum BoxBorderStyle {
   dotted,
   double,
   rounded,
+  bold,
 }
 
 /// Box border configuration.
@@ -779,6 +780,8 @@ class RenderDecoratedBox extends RenderObject
         return _BorderCharacters.dashed;
       case BoxBorderStyle.dotted:
         return _BorderCharacters.dotted;
+      case BoxBorderStyle.bold:
+        return _BorderCharacters.bold;
       case BoxBorderStyle.solid:
       case BoxBorderStyle.none:
       case null:
@@ -842,6 +845,15 @@ class _BorderCharacters {
     topRight: '┐',
     bottomLeft: '└',
     bottomRight: '┘',
+  );
+
+  static const bold = _BorderCharacters(
+    horizontal: '━',
+    vertical: '┃',
+    topLeft: '┏',
+    topRight: '┓',
+    bottomLeft: '┗',
+    bottomRight: '┛',
   );
 
   static const double = _BorderCharacters(

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -14,10 +14,10 @@ enum DividerStyle {
 ///
 /// The divider merges with box-drawing characters it overlaps, forming
 /// junctions instead of overwriting them. With a negative [indent] or
-/// [endIndent] it reaches outside its own bounds; those cells paint half-arm
-/// characters (`╶`/`╴`), so an end landing on a box border becomes a tee
-/// (`├`/`┤`). An end landing on a cell that is not a box-drawing character
-/// keeps the half-arm stub, so only reach into cells known to hold borders.
+/// [endIndent] it reaches outside its own bounds; those cells contribute
+/// only the arm pointing back into the rule, so an end landing on a box
+/// border becomes a tee (`├`/`┤`). An end with nothing to join is left
+/// unpainted, so reaching out is safe even where no border turns up.
 class Divider extends SingleChildRenderObjectComponent {
   const Divider({
     super.key,
@@ -70,10 +70,10 @@ class Divider extends SingleChildRenderObjectComponent {
 ///
 /// The divider merges with box-drawing characters it overlaps, forming
 /// junctions instead of overwriting them. With a negative [indent] or
-/// [endIndent] it reaches outside its own bounds; those cells paint half-arm
-/// characters (`╷`/`╵`), so an end landing on a box border becomes a tee
-/// (`┬`/`┴`). An end landing on a cell that is not a box-drawing character
-/// keeps the half-arm stub, so only reach into cells known to hold borders.
+/// [endIndent] it reaches outside its own bounds; those cells contribute
+/// only the arm pointing back into the rule, so an end landing on a box
+/// border becomes a tee (`┬`/`┴`). An end with nothing to join is left
+/// unpainted, so reaching out is safe even where no border turns up.
 class VerticalDivider extends SingleChildRenderObjectComponent {
   const VerticalDivider({
     super.key,
@@ -156,14 +156,6 @@ BoxCharArms? _capForStyle(
   }
   return start ? (none, none, weight, none) : (weight, none, none, none);
 }
-
-/// The character to paint for a cap, used when the cell underneath holds
-/// nothing to merge with. Falls back to the divider's own line character
-/// for caps Unicode cannot name, so a double end cell landing on empty
-/// space keeps drawing `═`/`║` as it always has.
-String _capCharacter(BoxCharArms cap, String lineChar) =>
-    boxCharacterForArms(cap) ?? lineChar;
-
 /// The line character for [style] along the given axis.
 String _characterForStyle(DividerStyle style, {required bool horizontal}) {
   switch (style) {
@@ -236,7 +228,8 @@ void _paintRun(
     }
     canvas.drawText(
       horizontal ? Offset(i.toDouble(), cross) : Offset(cross, i.toDouble()),
-      cap == null ? char : _capCharacter(cap, char),
+      // A capped cell is drawn from its arms; the character is unused.
+      char,
       style: TextStyle(color: color),
       blendBoxLines: blendLines,
       blendArms: cap,

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -123,27 +123,46 @@ class VerticalDivider extends SingleChildRenderObjectComponent {
   }
 }
 
-/// The half-arm characters painted at a blended divider's end cells, so an
-/// end landing on a border merges into a tee instead of a cross.
+/// The arms a blended divider's end cell contributes: just the one arm
+/// pointing back into the segment, so an end landing on a border merges
+/// into a tee instead of a cross.
 ///
-/// Returns null for styles without half-arm characters (no blending caps).
-String? _capForStyle(
+/// Arms rather than a character: a lone double arm has no glyph, though
+/// the junctions it forms do. See [mergeArmsIntoCharacter].
+///
+/// Returns null for the ascii style, which never merges.
+BoxCharArms? _capForStyle(
   DividerStyle style, {
   required bool horizontal,
   required bool start,
 }) {
+  final LineArm weight;
   switch (style) {
     case DividerStyle.single:
     case DividerStyle.dashed:
     case DividerStyle.dotted:
-      return horizontal ? (start ? '╶' : '╴') : (start ? '╷' : '╵');
+      weight = LineArm.light;
     case DividerStyle.bold:
-      return horizontal ? (start ? '╺' : '╸') : (start ? '╻' : '╹');
+      weight = LineArm.heavy;
     case DividerStyle.double:
+      weight = LineArm.double;
     case DividerStyle.ascii:
       return null;
   }
+  const none = LineArm.none;
+  // (up, right, down, left)
+  if (horizontal) {
+    return start ? (none, weight, none, none) : (none, none, none, weight);
+  }
+  return start ? (none, none, weight, none) : (weight, none, none, none);
 }
+
+/// The character to paint for a cap, used when the cell underneath holds
+/// nothing to merge with. Falls back to the divider's own line character
+/// for caps Unicode cannot name, so a double end cell landing on empty
+/// space keeps drawing `═`/`║` as it always has.
+String _capCharacter(BoxCharArms cap, String lineChar) =>
+    boxCharacterForArms(cap) ?? lineChar;
 
 class RenderDivider extends RenderObject {
   RenderDivider({
@@ -248,19 +267,20 @@ class RenderDivider extends RenderObject {
         : null;
 
     for (var x = startX; x < endX; x++) {
-      var cellChar = char;
+      BoxCharArms? cap;
       if (useCaps) {
         if (x == startX) {
-          cellChar = startCap ?? char;
+          cap = startCap;
         } else if (x == endX - 1) {
-          cellChar = endCap ?? char;
+          cap = endCap;
         }
       }
       canvas.drawText(
         Offset(x.toDouble(), y),
-        cellChar,
+        cap == null ? char : _capCharacter(cap, char),
         style: TextStyle(color: color),
         blendBoxLines: blendLines,
+        blendArms: cap,
       );
     }
   }
@@ -386,19 +406,20 @@ class RenderVerticalDivider extends RenderObject {
         : null;
 
     for (var y = startY; y < endY; y++) {
-      var cellChar = char;
+      BoxCharArms? cap;
       if (useCaps) {
         if (y == startY) {
-          cellChar = startCap ?? char;
+          cap = startCap;
         } else if (y == endY - 1) {
-          cellChar = endCap ?? char;
+          cap = endCap;
         }
       }
       canvas.drawText(
         Offset(x, y.toDouble()),
-        cellChar,
+        cap == null ? char : _capCharacter(cap, char),
         style: TextStyle(color: color),
         blendBoxLines: blendLines,
+        blendArms: cap,
       );
     }
   }

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -164,6 +164,80 @@ BoxCharArms? _capForStyle(
 String _capCharacter(BoxCharArms cap, String lineChar) =>
     boxCharacterForArms(cap) ?? lineChar;
 
+/// The line character for [style] along the given axis.
+String _characterForStyle(DividerStyle style, {required bool horizontal}) {
+  switch (style) {
+    case DividerStyle.single:
+      return horizontal ? '─' : '│';
+    case DividerStyle.double:
+      return horizontal ? '═' : '║';
+    case DividerStyle.dashed:
+      return horizontal ? '╌' : '╎';
+    case DividerStyle.dotted:
+      return horizontal ? '┈' : '┊';
+    case DividerStyle.bold:
+      return horizontal ? '━' : '┃';
+    case DividerStyle.ascii:
+      return horizontal ? '-' : '|';
+  }
+}
+
+/// Paints one run of divider cells along an axis, shared by both dividers.
+///
+/// [mainOrigin] and [mainExtent] are the offset and size along the axis the
+/// divider runs on; [cross] is the fixed coordinate on the other.
+void _paintRun(
+  TerminalCanvas canvas, {
+  required double mainOrigin,
+  required double mainExtent,
+  required double cross,
+  required double indent,
+  required double endIndent,
+  required DividerStyle style,
+  required Color color,
+  required bool horizontal,
+}) {
+  // Whole cells: layout offsets can be fractional, and an end has to land
+  // on exactly the cell it is drawn to.
+  final start = (mainOrigin + indent).round();
+  final end = (mainOrigin + mainExtent - endIndent).round();
+  if (start >= end) return;
+
+  final char = _characterForStyle(style, horizontal: horizontal);
+  // The ascii style has no box-drawing characters to merge.
+  final blendLines = style != DividerStyle.ascii;
+  // Cells reached via a negative indent lie outside the divider's own
+  // bounds, on top of foreign content such as a border. They contribute
+  // only the arm pointing into the segment, so a border cell forms a tee
+  // (├/┤) rather than a cross. Cells within bounds keep the full line
+  // character.
+  final useCaps = blendLines && end - start > 1;
+  final startCap = indent < 0
+      ? _capForStyle(style, horizontal: horizontal, start: true)
+      : null;
+  final endCap = endIndent < 0
+      ? _capForStyle(style, horizontal: horizontal, start: false)
+      : null;
+
+  for (var i = start; i < end; i++) {
+    BoxCharArms? cap;
+    if (useCaps) {
+      if (i == start) {
+        cap = startCap;
+      } else if (i == end - 1) {
+        cap = endCap;
+      }
+    }
+    canvas.drawText(
+      horizontal ? Offset(i.toDouble(), cross) : Offset(cross, i.toDouble()),
+      cap == null ? char : _capCharacter(cap, char),
+      style: TextStyle(color: color),
+      blendBoxLines: blendLines,
+      blendArms: cap,
+    );
+  }
+}
+
 class RenderDivider extends RenderObject {
   RenderDivider({
     required double height,
@@ -242,64 +316,17 @@ class RenderDivider extends RenderObject {
   void paint(TerminalCanvas canvas, Offset offset) {
     super.paint(canvas, offset);
 
-    // Work in whole cells: layout can produce fractional offsets, and the
-    // end caps must land on exactly the cells the characters are drawn to.
-    final startX = (offset.dx + indent).round();
-    final endX = (offset.dx + size.width - endIndent).round();
-    final y = offset.dy + (size.height / 2).floor();
-
-    if (startX >= endX) return;
-
-    final char = _getCharacterForStyle(style, horizontal: true);
-    // Box-line merging has no effect for the ascii style (its characters
-    // are not box-drawing characters).
-    final blendLines = style != DividerStyle.ascii;
-    // Cells reached via a negative indent lie outside the divider's own
-    // bounds, on top of foreign content such as a border. They contribute
-    // only the arm pointing into the segment, so a border cell forms a tee
-    // (├/┤) rather than a cross. Cells within bounds keep the full line
-    // character.
-    final useCaps = blendLines && endX - startX > 1;
-    final startCap =
-        indent < 0 ? _capForStyle(style, horizontal: true, start: true) : null;
-    final endCap = endIndent < 0
-        ? _capForStyle(style, horizontal: true, start: false)
-        : null;
-
-    for (var x = startX; x < endX; x++) {
-      BoxCharArms? cap;
-      if (useCaps) {
-        if (x == startX) {
-          cap = startCap;
-        } else if (x == endX - 1) {
-          cap = endCap;
-        }
-      }
-      canvas.drawText(
-        Offset(x.toDouble(), y),
-        cap == null ? char : _capCharacter(cap, char),
-        style: TextStyle(color: color),
-        blendBoxLines: blendLines,
-        blendArms: cap,
-      );
-    }
-  }
-
-  String _getCharacterForStyle(DividerStyle style, {required bool horizontal}) {
-    switch (style) {
-      case DividerStyle.single:
-        return horizontal ? '─' : '│';
-      case DividerStyle.double:
-        return horizontal ? '═' : '║';
-      case DividerStyle.dashed:
-        return horizontal ? '╌' : '╎';
-      case DividerStyle.dotted:
-        return horizontal ? '┈' : '┊';
-      case DividerStyle.bold:
-        return horizontal ? '━' : '┃';
-      case DividerStyle.ascii:
-        return horizontal ? '-' : '|';
-    }
+    _paintRun(
+      canvas,
+      mainOrigin: offset.dx,
+      mainExtent: size.width,
+      cross: offset.dy + (size.height / 2).floor(),
+      indent: indent,
+      endIndent: endIndent,
+      style: style,
+      color: color,
+      horizontal: true,
+    );
   }
 }
 
@@ -381,63 +408,16 @@ class RenderVerticalDivider extends RenderObject {
   void paint(TerminalCanvas canvas, Offset offset) {
     super.paint(canvas, offset);
 
-    // Work in whole cells: layout can produce fractional offsets, and the
-    // end caps must land on exactly the cells the characters are drawn to.
-    final x = offset.dx + (size.width / 2).floor();
-    final startY = (offset.dy + indent).round();
-    final endY = (offset.dy + size.height - endIndent).round();
-
-    if (startY >= endY) return;
-
-    final char = _getCharacterForStyle(style, horizontal: false);
-    // Box-line merging has no effect for the ascii style (its characters
-    // are not box-drawing characters).
-    final blendLines = style != DividerStyle.ascii;
-    // Cells reached via a negative indent lie outside the divider's own
-    // bounds, on top of foreign content such as a border. They contribute
-    // only the arm pointing into the segment, so a border cell forms a tee
-    // (┬/┴) rather than a cross. Cells within bounds keep the full line
-    // character.
-    final useCaps = blendLines && endY - startY > 1;
-    final startCap =
-        indent < 0 ? _capForStyle(style, horizontal: false, start: true) : null;
-    final endCap = endIndent < 0
-        ? _capForStyle(style, horizontal: false, start: false)
-        : null;
-
-    for (var y = startY; y < endY; y++) {
-      BoxCharArms? cap;
-      if (useCaps) {
-        if (y == startY) {
-          cap = startCap;
-        } else if (y == endY - 1) {
-          cap = endCap;
-        }
-      }
-      canvas.drawText(
-        Offset(x, y.toDouble()),
-        cap == null ? char : _capCharacter(cap, char),
-        style: TextStyle(color: color),
-        blendBoxLines: blendLines,
-        blendArms: cap,
-      );
-    }
-  }
-
-  String _getCharacterForStyle(DividerStyle style, {required bool horizontal}) {
-    switch (style) {
-      case DividerStyle.single:
-        return horizontal ? '─' : '│';
-      case DividerStyle.double:
-        return horizontal ? '═' : '║';
-      case DividerStyle.dashed:
-        return horizontal ? '╌' : '╎';
-      case DividerStyle.dotted:
-        return horizontal ? '┈' : '┊';
-      case DividerStyle.bold:
-        return horizontal ? '━' : '┃';
-      case DividerStyle.ascii:
-        return horizontal ? '-' : '|';
-    }
+    _paintRun(
+      canvas,
+      mainOrigin: offset.dy,
+      mainExtent: size.height,
+      cross: offset.dx + (size.width / 2).floor(),
+      indent: indent,
+      endIndent: endIndent,
+      style: style,
+      color: color,
+      horizontal: false,
+    );
   }
 }

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -10,6 +10,14 @@ enum DividerStyle {
   ascii,
 }
 
+/// A horizontal rule.
+///
+/// The divider merges with box-drawing characters it overlaps, forming
+/// junctions instead of overwriting them. With a negative [indent] or
+/// [endIndent] it reaches outside its own bounds; those cells paint half-arm
+/// characters (`╶`/`╴`), so an end landing on a box border becomes a tee
+/// (`├`/`┤`). An end landing on a cell that is not a box-drawing character
+/// keeps the half-arm stub, so only reach into cells known to hold borders.
 class Divider extends SingleChildRenderObjectComponent {
   const Divider({
     super.key,
@@ -58,6 +66,14 @@ class Divider extends SingleChildRenderObjectComponent {
   }
 }
 
+/// A vertical rule.
+///
+/// The divider merges with box-drawing characters it overlaps, forming
+/// junctions instead of overwriting them. With a negative [indent] or
+/// [endIndent] it reaches outside its own bounds; those cells paint half-arm
+/// characters (`╷`/`╵`), so an end landing on a box border becomes a tee
+/// (`┬`/`┴`). An end landing on a cell that is not a box-drawing character
+/// keeps the half-arm stub, so only reach into cells known to hold borders.
 class VerticalDivider extends SingleChildRenderObjectComponent {
   const VerticalDivider({
     super.key,
@@ -104,6 +120,28 @@ class VerticalDivider extends SingleChildRenderObjectComponent {
       ..endIndent = endIndent
       ..color = color ?? theme.outline
       ..style = style;
+  }
+}
+
+/// The half-arm characters painted at a blended divider's end cells, so an
+/// end landing on a border merges into a tee instead of a cross.
+///
+/// Returns null for styles without half-arm characters (no blending caps).
+String? _capForStyle(
+  DividerStyle style, {
+  required bool horizontal,
+  required bool start,
+}) {
+  switch (style) {
+    case DividerStyle.single:
+    case DividerStyle.dashed:
+    case DividerStyle.dotted:
+      return horizontal ? (start ? '╶' : '╴') : (start ? '╷' : '╵');
+    case DividerStyle.bold:
+      return horizontal ? (start ? '╺' : '╸') : (start ? '╻' : '╹');
+    case DividerStyle.double:
+    case DividerStyle.ascii:
+      return null;
   }
 }
 
@@ -185,19 +223,44 @@ class RenderDivider extends RenderObject {
   void paint(TerminalCanvas canvas, Offset offset) {
     super.paint(canvas, offset);
 
-    final startX = offset.dx + indent;
-    final endX = offset.dx + size.width - endIndent;
+    // Work in whole cells: layout can produce fractional offsets, and the
+    // end caps must land on exactly the cells the characters are drawn to.
+    final startX = (offset.dx + indent).round();
+    final endX = (offset.dx + size.width - endIndent).round();
     final y = offset.dy + (size.height / 2).floor();
 
     if (startX >= endX) return;
 
-    String char = _getCharacterForStyle(style, horizontal: true);
+    final char = _getCharacterForStyle(style, horizontal: true);
+    // Box-line merging has no effect for the ascii style (its characters
+    // are not box-drawing characters).
+    final blendLines = style != DividerStyle.ascii;
+    // Cells reached via a negative indent lie outside the divider's own
+    // bounds, on top of foreign content such as a border. They contribute
+    // only the arm pointing into the segment, so a border cell forms a tee
+    // (├/┤) rather than a cross. Cells within bounds keep the full line
+    // character.
+    final useCaps = blendLines && endX - startX > 1;
+    final startCap =
+        indent < 0 ? _capForStyle(style, horizontal: true, start: true) : null;
+    final endCap = endIndent < 0
+        ? _capForStyle(style, horizontal: true, start: false)
+        : null;
 
-    for (double x = startX; x < endX; x += 1) {
+    for (var x = startX; x < endX; x++) {
+      var cellChar = char;
+      if (useCaps) {
+        if (x == startX) {
+          cellChar = startCap ?? char;
+        } else if (x == endX - 1) {
+          cellChar = endCap ?? char;
+        }
+      }
       canvas.drawText(
-        Offset(x, y),
-        char,
+        Offset(x.toDouble(), y),
+        cellChar,
         style: TextStyle(color: color),
+        blendBoxLines: blendLines,
       );
     }
   }
@@ -298,19 +361,44 @@ class RenderVerticalDivider extends RenderObject {
   void paint(TerminalCanvas canvas, Offset offset) {
     super.paint(canvas, offset);
 
+    // Work in whole cells: layout can produce fractional offsets, and the
+    // end caps must land on exactly the cells the characters are drawn to.
     final x = offset.dx + (size.width / 2).floor();
-    final startY = offset.dy + indent;
-    final endY = offset.dy + size.height - endIndent;
+    final startY = (offset.dy + indent).round();
+    final endY = (offset.dy + size.height - endIndent).round();
 
     if (startY >= endY) return;
 
-    String char = _getCharacterForStyle(style, horizontal: false);
+    final char = _getCharacterForStyle(style, horizontal: false);
+    // Box-line merging has no effect for the ascii style (its characters
+    // are not box-drawing characters).
+    final blendLines = style != DividerStyle.ascii;
+    // Cells reached via a negative indent lie outside the divider's own
+    // bounds, on top of foreign content such as a border. They contribute
+    // only the arm pointing into the segment, so a border cell forms a tee
+    // (┬/┴) rather than a cross. Cells within bounds keep the full line
+    // character.
+    final useCaps = blendLines && endY - startY > 1;
+    final startCap =
+        indent < 0 ? _capForStyle(style, horizontal: false, start: true) : null;
+    final endCap = endIndent < 0
+        ? _capForStyle(style, horizontal: false, start: false)
+        : null;
 
-    for (double y = startY; y < endY; y += 1) {
+    for (var y = startY; y < endY; y++) {
+      var cellChar = char;
+      if (useCaps) {
+        if (y == startY) {
+          cellChar = startCap ?? char;
+        } else if (y == endY - 1) {
+          cellChar = endCap ?? char;
+        }
+      }
       canvas.drawText(
-        Offset(x, y),
-        char,
+        Offset(x, y.toDouble()),
+        cellChar,
         style: TextStyle(color: color),
+        blendBoxLines: blendLines,
       );
     }
   }

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -156,6 +156,7 @@ BoxCharArms? _capForStyle(
   }
   return start ? (none, none, weight, none) : (weight, none, none, none);
 }
+
 /// The line character for [style] along the given axis.
 String _characterForStyle(DividerStyle style, {required bool horizontal}) {
   switch (style) {
@@ -226,14 +227,18 @@ void _paintRun(
     } else if (i == end - 1) {
       cap = endCap;
     }
-    canvas.drawText(
-      horizontal ? Offset(i.toDouble(), cross) : Offset(cross, i.toDouble()),
-      // A capped cell is drawn from its arms; the character is unused.
-      char,
-      style: TextStyle(color: color),
-      blendBoxLines: blendLines,
-      blendArms: cap,
-    );
+    final at =
+        horizontal ? Offset(i.toDouble(), cross) : Offset(cross, i.toDouble());
+    if (cap != null) {
+      canvas.drawJunction(at, cap, style: TextStyle(color: color));
+    } else {
+      canvas.drawText(
+        at,
+        char,
+        style: TextStyle(color: color),
+        blendBoxLines: blendLines,
+      );
+    }
   }
 }
 

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -210,16 +210,17 @@ void _paintRun(
   final char = _characterForStyle(style, horizontal: horizontal);
   // The ascii style has no box-drawing characters to merge.
   final blendLines = style != DividerStyle.ascii;
-  // Cells reached via a negative indent lie outside the divider's own
-  // bounds, on top of foreign content such as a border. They contribute
-  // only the arm pointing into the segment, so a border cell forms a tee
-  // (├/┤) rather than a cross. Cells within bounds keep the full line
-  // character.
+  // Cells outside the divider's own bounds contribute only the arm pointing
+  // back into it, so a border cell forms a tee (├/┤) rather than a cross.
+  // Which cells those are comes from the run's rounded bounds, not the sign
+  // of the indent: -0.5 rounds back onto the divider's own first cell.
+  final ownStart = mainOrigin.round();
+  final ownEnd = (mainOrigin + mainExtent).round();
   final useCaps = blendLines && end - start > 1;
-  final startCap = indent < 0
+  final startCap = start < ownStart
       ? _capForStyle(style, horizontal: horizontal, start: true)
       : null;
-  final endCap = endIndent < 0
+  final endCap = end > ownEnd
       ? _capForStyle(style, horizontal: horizontal, start: false)
       : null;
 

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -197,6 +197,10 @@ void _paintRun(
   required Color color,
   required bool horizontal,
 }) {
+  // An unbounded parent leaves the extent infinite, and rounding a
+  // non-finite value throws.
+  if (!mainExtent.isFinite) return;
+
   // Whole cells: layout offsets can be fractional, and an end has to land
   // on exactly the cell it is drawn to.
   final start = (mainOrigin + indent).round();

--- a/lib/src/components/divider.dart
+++ b/lib/src/components/divider.dart
@@ -203,6 +203,12 @@ void _paintRun(
 
   // Whole cells: layout offsets can be fractional, and an end has to land
   // on exactly the cell it is drawn to.
+  final ownStart = mainOrigin.round();
+  final ownEnd = (mainOrigin + mainExtent).round();
+  // A rule with no cells of its own has nothing for an end to join it to,
+  // so it draws nothing at all.
+  if (ownStart >= ownEnd) return;
+
   final start = (mainOrigin + indent).round();
   final end = (mainOrigin + mainExtent - endIndent).round();
   if (start >= end) return;
@@ -212,26 +218,21 @@ void _paintRun(
   final blendLines = style != DividerStyle.ascii;
   // Cells outside the divider's own bounds contribute only the arm pointing
   // back into it, so a border cell forms a tee (├/┤) rather than a cross.
-  // Which cells those are comes from the run's rounded bounds, not the sign
-  // of the indent: -0.5 rounds back onto the divider's own first cell.
-  final ownStart = mainOrigin.round();
-  final ownEnd = (mainOrigin + mainExtent).round();
-  final useCaps = blendLines && end - start > 1;
-  final startCap = start < ownStart
+  // Which cells those are comes from the run's rounded bounds: an indent of
+  // -0.5 rounds back onto the divider's own first cell, so it is not an end.
+  final startCap = blendLines && start < ownStart
       ? _capForStyle(style, horizontal: horizontal, start: true)
       : null;
-  final endCap = end > ownEnd
+  final endCap = blendLines && end > ownEnd
       ? _capForStyle(style, horizontal: horizontal, start: false)
       : null;
 
   for (var i = start; i < end; i++) {
     BoxCharArms? cap;
-    if (useCaps) {
-      if (i == start) {
-        cap = startCap;
-      } else if (i == end - 1) {
-        cap = endCap;
-      }
+    if (i == start) {
+      cap = startCap;
+    } else if (i == end - 1) {
+      cap = endCap;
     }
     canvas.drawText(
       horizontal ? Offset(i.toDouble(), cross) : Offset(cross, i.toDouble()),

--- a/lib/src/framework/terminal_canvas.dart
+++ b/lib/src/framework/terminal_canvas.dart
@@ -114,10 +114,19 @@ class TerminalCanvas {
 
       var char = grapheme;
       if (blendBoxLines) {
-        char = (blendArms != null
-                ? mergeArmsIntoCharacter(blendArms, existingCell.char)
-                : mergeBoxCharacters(grapheme, existingCell.char)) ??
-            grapheme;
+        if (blendArms != null) {
+          var merged = mergeArmsIntoCharacter(blendArms, existingCell.char);
+          if (merged == null) {
+            // Nothing to join, so the cell is not ours to write - a space
+            // is as opaque as any other character, the border run being
+            // already absent under a title's padding.
+            currentColumn += width;
+            continue;
+          }
+          char = merged;
+        } else {
+          char = mergeBoxCharacters(grapheme, existingCell.char) ?? grapheme;
+        }
 
         // The merge kept what was there and it is not what we asked to
         // draw, so the cell is not ours to change - style included. Drawing

--- a/lib/src/framework/terminal_canvas.dart
+++ b/lib/src/framework/terminal_canvas.dart
@@ -118,6 +118,15 @@ class TerminalCanvas {
                 ? mergeArmsIntoCharacter(blendArms, existingCell.char)
                 : mergeBoxCharacters(grapheme, existingCell.char)) ??
             grapheme;
+
+        // The merge kept what was there and it is not what we asked to
+        // draw, so the cell is not ours to change - style included. Drawing
+        // a glyph onto its twin is not this case: the result equals the
+        // grapheme.
+        if (char == existingCell.char && char != grapheme) {
+          currentColumn += width;
+          continue;
+        }
       }
 
       _buffer.setCell(

--- a/lib/src/framework/terminal_canvas.dart
+++ b/lib/src/framework/terminal_canvas.dart
@@ -67,14 +67,8 @@ class TerminalCanvas {
   /// merge with box-drawing characters already in the buffer instead of
   /// overwriting them, forming junctions: a `│` drawn onto a `─` border
   /// becomes `┬`. Non box-drawing characters are unaffected.
-  ///
-  /// [blendArms] overrides the arms each grapheme contributes, for arm sets
-  /// Unicode cannot name. Applies to every grapheme in [text], so pass a
-  /// single character. Ignored unless [blendBoxLines] is true.
   void drawText(Offset position, String text,
-      {TextStyle? style,
-      bool blendBoxLines = false,
-      BoxCharArms? blendArms}) {
+      {TextStyle? style, bool blendBoxLines = false}) {
     final x = position.dx.round();
     final y = position.dy.round();
 
@@ -114,19 +108,7 @@ class TerminalCanvas {
 
       var char = grapheme;
       if (blendBoxLines) {
-        if (blendArms != null) {
-          var merged = mergeArmsIntoCharacter(blendArms, existingCell.char);
-          if (merged == null) {
-            // Nothing to join, so the cell is not ours to write - a space
-            // is as opaque as any other character, the border run being
-            // already absent under a title's padding.
-            currentColumn += width;
-            continue;
-          }
-          char = merged;
-        } else {
-          char = mergeBoxCharacters(grapheme, existingCell.char) ?? grapheme;
-        }
+        char = mergeBoxCharacters(grapheme, existingCell.char) ?? grapheme;
 
         // The merge kept what was there and it is not what we asked to
         // draw, so the cell is not ours to change - style included. Drawing
@@ -173,6 +155,36 @@ class TerminalCanvas {
 
       currentColumn += width;
     }
+  }
+
+  /// Merges [arms] into the single cell at [position].
+  ///
+  /// The cell is left untouched when there is nothing there to join, so a
+  /// space, a letter of a border title, or a wall this arm has no junction with
+  /// (fx bold on double) all survive.
+  void drawJunction(Offset position, BoxCharArms arms, {TextStyle? style}) {
+    final x = position.dx.round();
+    final y = position.dy.round();
+
+    if (x < 0 || y < 0 || x >= area.width || y >= area.height) {
+      return;
+    }
+
+    final cellX = area.left.round() + x;
+    final cellY = area.top.round() + y;
+    final existingCell = _buffer.getCell(cellX, cellY);
+
+    final merged = mergeArmsIntoCharacter(arms, existingCell.char);
+    if (merged == null || merged == existingCell.char) return;
+
+    _buffer.setCell(
+      cellX,
+      cellY,
+      Cell(
+        char: merged,
+        style: _blendStyle(style ?? const TextStyle(), existingCell),
+      ),
+    );
   }
 
   /// Fill a rectangle with a character

--- a/lib/src/framework/terminal_canvas.dart
+++ b/lib/src/framework/terminal_canvas.dart
@@ -67,8 +67,14 @@ class TerminalCanvas {
   /// merge with box-drawing characters already in the buffer instead of
   /// overwriting them, forming junctions: a `│` drawn onto a `─` border
   /// becomes `┬`. Non box-drawing characters are unaffected.
+  ///
+  /// [blendArms] overrides the arms each grapheme contributes, for arm sets
+  /// Unicode cannot name. Applies to every grapheme in [text], so pass a
+  /// single character. Ignored unless [blendBoxLines] is true.
   void drawText(Offset position, String text,
-      {TextStyle? style, bool blendBoxLines = false}) {
+      {TextStyle? style,
+      bool blendBoxLines = false,
+      BoxCharArms? blendArms}) {
     final x = position.dx.round();
     final y = position.dy.round();
 
@@ -108,7 +114,10 @@ class TerminalCanvas {
 
       var char = grapheme;
       if (blendBoxLines) {
-        char = mergeBoxCharacters(grapheme, existingCell.char) ?? grapheme;
+        char = (blendArms != null
+                ? mergeArmsIntoCharacter(blendArms, existingCell.char)
+                : mergeBoxCharacters(grapheme, existingCell.char)) ??
+            grapheme;
       }
 
       _buffer.setCell(

--- a/lib/src/framework/terminal_canvas.dart
+++ b/lib/src/framework/terminal_canvas.dart
@@ -6,6 +6,7 @@ import 'package:nocterm/src/rectangle.dart';
 
 import '../buffer.dart';
 import '../style.dart';
+import '../utils/box_line_merging.dart';
 import '../utils/unicode_width.dart';
 import 'framework.dart';
 
@@ -61,7 +62,13 @@ class TerminalCanvas {
   }
 
   /// Draw text at the given position
-  void drawText(Offset position, String text, {TextStyle? style}) {
+  ///
+  /// When [blendBoxLines] is true, box-drawing characters (U+2500–U+257F)
+  /// merge with box-drawing characters already in the buffer instead of
+  /// overwriting them, forming junctions: a `│` drawn onto a `─` border
+  /// becomes `┬`. Non box-drawing characters are unaffected.
+  void drawText(Offset position, String text,
+      {TextStyle? style, bool blendBoxLines = false}) {
     final x = position.dx.round();
     final y = position.dy.round();
 
@@ -99,11 +106,16 @@ class TerminalCanvas {
       final effectiveStyle = style ?? const TextStyle();
       final finalStyle = _blendStyle(effectiveStyle, existingCell);
 
+      var char = grapheme;
+      if (blendBoxLines) {
+        char = mergeBoxCharacters(grapheme, existingCell.char) ?? grapheme;
+      }
+
       _buffer.setCell(
         cellX,
         cellY,
         Cell(
-          char: grapheme, // Use the full grapheme cluster, not individual runes
+          char: char, // Use the full grapheme cluster, not individual runes
           style: finalStyle,
         ),
       );

--- a/lib/src/utils/box_line_merging.dart
+++ b/lib/src/utils/box_line_merging.dart
@@ -1,0 +1,237 @@
+/// Merging of Unicode box-drawing characters (U+2500–U+257F).
+///
+/// Models every line character as four arms (up, right, down, left), each
+/// with a weight. Drawing one line character on top of another can then
+/// combine their arms and produce the proper junction glyph: a vertical line
+/// meeting a horizontal border becomes `┬`, a divider hitting a box's left
+/// edge becomes `├`, two crossing dividers become `┼`.
+///
+/// Used by [TerminalCanvas.drawText] when `blendBoxLines` is enabled.
+library;
+
+/// The weight of one arm of a box-drawing character.
+enum LineArm {
+  /// No line in this direction.
+  none,
+
+  /// A light (thin) line, e.g. `─`.
+  light,
+
+  /// A heavy (bold) line, e.g. `━`.
+  heavy,
+
+  /// A double line, e.g. `═`.
+  double,
+}
+
+/// The four arms of a box-drawing character: (up, right, down, left).
+typedef BoxCharArms = (LineArm, LineArm, LineArm, LineArm);
+
+const _n = LineArm.none;
+const _l = LineArm.light;
+const _h = LineArm.heavy;
+const _d = LineArm.double;
+
+/// Arms for every mergeable character in the box-drawing block.
+///
+/// Excluded on purpose: the diagonals `╱ ╲ ╳` (not axis-aligned lines).
+/// Dashed and dotted variants map to the same arms as their solid
+/// counterparts so a dashed divider still forms solid junctions.
+///
+/// Entry order matters for [_armsToChar]: the canonical (solid, square)
+/// character for a given arm set must appear before any alias sharing those
+/// arms (dashed variants, rounded corners), because the reverse lookup keeps
+/// the first entry.
+const Map<String, BoxCharArms> _charToArms = {
+  // Straight lines.
+  '─': (_n, _l, _n, _l),
+  '━': (_n, _h, _n, _h),
+  '│': (_l, _n, _l, _n),
+  '┃': (_h, _n, _h, _n),
+  // Dashed/dotted variants (aliases of the straight lines above).
+  '┄': (_n, _l, _n, _l),
+  '┅': (_n, _h, _n, _h),
+  '┆': (_l, _n, _l, _n),
+  '┇': (_h, _n, _h, _n),
+  '┈': (_n, _l, _n, _l),
+  '┉': (_n, _h, _n, _h),
+  '┊': (_l, _n, _l, _n),
+  '┋': (_h, _n, _h, _n),
+  '╌': (_n, _l, _n, _l),
+  '╍': (_n, _h, _n, _h),
+  '╎': (_l, _n, _l, _n),
+  '╏': (_h, _n, _h, _n),
+  // Corners.
+  '┌': (_n, _l, _l, _n),
+  '┍': (_n, _h, _l, _n),
+  '┎': (_n, _l, _h, _n),
+  '┏': (_n, _h, _h, _n),
+  '┐': (_n, _n, _l, _l),
+  '┑': (_n, _n, _l, _h),
+  '┒': (_n, _n, _h, _l),
+  '┓': (_n, _n, _h, _h),
+  '└': (_l, _l, _n, _n),
+  '┕': (_l, _h, _n, _n),
+  '┖': (_h, _l, _n, _n),
+  '┗': (_h, _h, _n, _n),
+  '┘': (_l, _n, _n, _l),
+  '┙': (_l, _n, _n, _h),
+  '┚': (_h, _n, _n, _l),
+  '┛': (_h, _n, _n, _h),
+  // Rounded corners (aliases of the square corners above).
+  '╭': (_n, _l, _l, _n),
+  '╮': (_n, _n, _l, _l),
+  '╯': (_l, _n, _n, _l),
+  '╰': (_l, _l, _n, _n),
+  // Tees: vertical with right arm.
+  '├': (_l, _l, _l, _n),
+  '┝': (_l, _h, _l, _n),
+  '┞': (_h, _l, _l, _n),
+  '┟': (_l, _l, _h, _n),
+  '┠': (_h, _l, _h, _n),
+  '┡': (_h, _h, _l, _n),
+  '┢': (_l, _h, _h, _n),
+  '┣': (_h, _h, _h, _n),
+  // Tees: vertical with left arm.
+  '┤': (_l, _n, _l, _l),
+  '┥': (_l, _n, _l, _h),
+  '┦': (_h, _n, _l, _l),
+  '┧': (_l, _n, _h, _l),
+  '┨': (_h, _n, _h, _l),
+  '┩': (_h, _n, _l, _h),
+  '┪': (_l, _n, _h, _h),
+  '┫': (_h, _n, _h, _h),
+  // Tees: horizontal with down arm.
+  '┬': (_n, _l, _l, _l),
+  '┭': (_n, _l, _l, _h),
+  '┮': (_n, _h, _l, _l),
+  '┯': (_n, _h, _l, _h),
+  '┰': (_n, _l, _h, _l),
+  '┱': (_n, _l, _h, _h),
+  '┲': (_n, _h, _h, _l),
+  '┳': (_n, _h, _h, _h),
+  // Tees: horizontal with up arm.
+  '┴': (_l, _l, _n, _l),
+  '┵': (_l, _l, _n, _h),
+  '┶': (_l, _h, _n, _l),
+  '┷': (_l, _h, _n, _h),
+  '┸': (_h, _l, _n, _l),
+  '┹': (_h, _l, _n, _h),
+  '┺': (_h, _h, _n, _l),
+  '┻': (_h, _h, _n, _h),
+  // Crosses.
+  '┼': (_l, _l, _l, _l),
+  '┽': (_l, _l, _l, _h),
+  '┾': (_l, _h, _l, _l),
+  '┿': (_l, _h, _l, _h),
+  '╀': (_h, _l, _l, _l),
+  '╁': (_l, _l, _h, _l),
+  '╂': (_h, _l, _h, _l),
+  '╃': (_h, _l, _l, _h),
+  '╄': (_h, _h, _l, _l),
+  '╅': (_l, _l, _h, _h),
+  '╆': (_l, _h, _h, _l),
+  '╇': (_h, _h, _l, _h),
+  '╈': (_l, _h, _h, _h),
+  '╉': (_h, _l, _h, _h),
+  '╊': (_h, _h, _h, _l),
+  '╋': (_h, _h, _h, _h),
+  // Double lines.
+  '═': (_n, _d, _n, _d),
+  '║': (_d, _n, _d, _n),
+  // Double/single corners.
+  '╒': (_n, _d, _l, _n),
+  '╓': (_n, _l, _d, _n),
+  '╔': (_n, _d, _d, _n),
+  '╕': (_n, _n, _l, _d),
+  '╖': (_n, _n, _d, _l),
+  '╗': (_n, _n, _d, _d),
+  '╘': (_l, _d, _n, _n),
+  '╙': (_d, _l, _n, _n),
+  '╚': (_d, _d, _n, _n),
+  '╛': (_l, _n, _n, _d),
+  '╜': (_d, _n, _n, _l),
+  '╝': (_d, _n, _n, _d),
+  // Double/single tees and crosses.
+  '╞': (_l, _d, _l, _n),
+  '╟': (_d, _l, _d, _n),
+  '╠': (_d, _d, _d, _n),
+  '╡': (_l, _n, _l, _d),
+  '╢': (_d, _n, _d, _l),
+  '╣': (_d, _n, _d, _d),
+  '╤': (_n, _d, _l, _d),
+  '╥': (_n, _l, _d, _l),
+  '╦': (_n, _d, _d, _d),
+  '╧': (_l, _d, _n, _d),
+  '╨': (_d, _l, _n, _l),
+  '╩': (_d, _d, _n, _d),
+  '╪': (_l, _d, _l, _d),
+  '╫': (_d, _l, _d, _l),
+  '╬': (_d, _d, _d, _d),
+  // Half lines (segment ends). These are what blended divider endpoints
+  // paint, so an endpoint only contributes the arm pointing into the
+  // segment: `╷` on a top border `─` merges to `┬`, never `┼`.
+  '╴': (_n, _n, _n, _l),
+  '╵': (_l, _n, _n, _n),
+  '╶': (_n, _l, _n, _n),
+  '╷': (_n, _n, _l, _n),
+  '╸': (_n, _n, _n, _h),
+  '╹': (_h, _n, _n, _n),
+  '╺': (_n, _h, _n, _n),
+  '╻': (_n, _n, _h, _n),
+  // Mixed-weight lines.
+  '╼': (_n, _h, _n, _l),
+  '╽': (_l, _n, _h, _n),
+  '╾': (_n, _l, _n, _h),
+  '╿': (_h, _n, _l, _n),
+};
+
+/// Reverse lookup from arms to the canonical character.
+///
+/// First entry in [_charToArms] wins, so aliases (dashed lines, rounded
+/// corners) resolve to their solid, square counterpart.
+final Map<BoxCharArms, String> _armsToChar = () {
+  final map = <BoxCharArms, String>{};
+  for (final entry in _charToArms.entries) {
+    map.putIfAbsent(entry.value, () => entry.key);
+  }
+  return map;
+}();
+
+/// Merges [newChar] drawn on top of [existingChar].
+///
+/// Returns the junction character whose arms combine both, or null when
+/// either character is not a mergeable box-drawing character (the caller
+/// should fall back to a plain overwrite).
+///
+/// Per arm, the new character wins where it has a line and the existing
+/// character's arm is kept where it doesn't. This makes segment-versus-line
+/// merges order independent: `╴` onto `│` and `│` onto `╴` both give `┤`.
+///
+/// When the combined arms equal the existing character's arms, the existing
+/// character is returned unchanged so aliases keep their identity - drawing
+/// over a rounded corner `╭` with a subset of its arms does not square it
+/// off to `┌`.
+///
+/// Combinations with no Unicode representation (e.g. a double arm meeting a
+/// heavy arm) fall back to [newChar].
+String? mergeBoxCharacters(String newChar, String existingChar) {
+  final newArms = _charToArms[newChar];
+  final existingArms = _charToArms[existingChar];
+  if (newArms == null || existingArms == null) return null;
+
+  LineArm pick(LineArm a, LineArm b) => a == LineArm.none ? b : a;
+  final merged = (
+    pick(newArms.$1, existingArms.$1),
+    pick(newArms.$2, existingArms.$2),
+    pick(newArms.$3, existingArms.$3),
+    pick(newArms.$4, existingArms.$4),
+  );
+
+  if (merged == existingArms) return existingChar;
+  if (merged == newArms) return newChar;
+  return _armsToChar[merged] ?? newChar;
+}
+
+/// Whether [char] participates in box-line merging.
+bool isMergeableBoxCharacter(String char) => _charToArms.containsKey(char);

--- a/lib/src/utils/box_line_merging.dart
+++ b/lib/src/utils/box_line_merging.dart
@@ -248,8 +248,6 @@ String? mergeArmsIntoCharacter(BoxCharArms newArms, String existingChar) {
   return _armsToChar[merged];
 }
 
-/// Whether [char] participates in box-line merging.
-bool isMergeableBoxCharacter(String char) => _charToArms.containsKey(char);
 /// Combines two arm sets, the new character winning wherever it has a line.
 BoxCharArms _combine(BoxCharArms newArms, BoxCharArms existingArms) {
   LineArm pick(LineArm a, LineArm b) => a == LineArm.none ? b : a;

--- a/lib/src/utils/box_line_merging.dart
+++ b/lib/src/utils/box_line_merging.dart
@@ -248,13 +248,8 @@ String? mergeArmsIntoCharacter(BoxCharArms newArms, String existingChar) {
   return _armsToChar[merged];
 }
 
-/// The canonical box-drawing character for [arms], or null when Unicode
-/// has none - as for a lone double-weight arm.
-String? boxCharacterForArms(BoxCharArms arms) => _armsToChar[arms];
-
 /// Whether [char] participates in box-line merging.
 bool isMergeableBoxCharacter(String char) => _charToArms.containsKey(char);
-
 /// Combines two arm sets, the new character winning wherever it has a line.
 BoxCharArms _combine(BoxCharArms newArms, BoxCharArms existingArms) {
   LineArm pick(LineArm a, LineArm b) => a == LineArm.none ? b : a;

--- a/lib/src/utils/box_line_merging.dart
+++ b/lib/src/utils/box_line_merging.dart
@@ -220,18 +220,45 @@ String? mergeBoxCharacters(String newChar, String existingChar) {
   final existingArms = _charToArms[existingChar];
   if (newArms == null || existingArms == null) return null;
 
-  LineArm pick(LineArm a, LineArm b) => a == LineArm.none ? b : a;
-  final merged = (
-    pick(newArms.$1, existingArms.$1),
-    pick(newArms.$2, existingArms.$2),
-    pick(newArms.$3, existingArms.$3),
-    pick(newArms.$4, existingArms.$4),
-  );
-
+  final merged = _combine(newArms, existingArms);
   if (merged == existingArms) return existingChar;
   if (merged == newArms) return newChar;
   return _armsToChar[merged] ?? newChar;
 }
 
+/// Merges the arms [newArms] drawn on top of [existingChar].
+///
+/// The arms-level counterpart of [mergeBoxCharacters], for arm sets Unicode
+/// cannot name: half lines exist at light (`╴╵╶╷`) and heavy (`╸╹╺╻`) weight
+/// only, so a lone double arm has no character - though every junction it
+/// forms does.
+///
+/// Merges per arm as [mergeBoxCharacters] does. Returns null when
+/// [existingChar] is not mergeable, or the combination has no Unicode
+/// representation.
+String? mergeArmsIntoCharacter(BoxCharArms newArms, String existingChar) {
+  final existingArms = _charToArms[existingChar];
+  if (existingArms == null) return null;
+
+  final merged = _combine(newArms, existingArms);
+  if (merged == existingArms) return existingChar;
+  return _armsToChar[merged];
+}
+
+/// The canonical box-drawing character for [arms], or null when Unicode
+/// has none - as for a lone double-weight arm.
+String? boxCharacterForArms(BoxCharArms arms) => _armsToChar[arms];
+
 /// Whether [char] participates in box-line merging.
 bool isMergeableBoxCharacter(String char) => _charToArms.containsKey(char);
+
+/// Combines two arm sets, the new character winning wherever it has a line.
+BoxCharArms _combine(BoxCharArms newArms, BoxCharArms existingArms) {
+  LineArm pick(LineArm a, LineArm b) => a == LineArm.none ? b : a;
+  return (
+    pick(newArms.$1, existingArms.$1),
+    pick(newArms.$2, existingArms.$2),
+    pick(newArms.$3, existingArms.$3),
+    pick(newArms.$4, existingArms.$4),
+  );
+}

--- a/lib/src/utils/box_line_merging.dart
+++ b/lib/src/utils/box_line_merging.dart
@@ -221,7 +221,10 @@ String? mergeBoxCharacters(String newChar, String existingChar) {
   if (newArms == null || existingArms == null) return null;
 
   final merged = _combine(newArms, existingArms);
-  if (merged == existingArms) return existingChar;
+  // Keep the existing character only when the new one adds nothing: a stub
+  // must not square a rounded corner. Equal arms are a style choice, and
+  // the character being drawn is on top.
+  if (merged == existingArms && newArms != existingArms) return existingChar;
   if (merged == newArms) return newChar;
   return _armsToChar[merged] ?? newChar;
 }

--- a/lib/src/utils/log_server.dart
+++ b/lib/src/utils/log_server.dart
@@ -30,10 +30,20 @@ import 'nocterm_paths.dart';
 class LogServer {
   LogServer({
     this.maxBufferSize = 10000,
-  });
+    String? portFilePath,
+  }) : _portFilePath = portFilePath;
 
   /// Maximum number of log entries to keep in buffer
   final int maxBufferSize;
+
+  final String? _portFilePath;
+
+  /// Where this server publishes its port for CLI discovery.
+  ///
+  /// Defaults to the global file for the current process. That path is
+  /// keyed by pid, so two servers running in one process would share it -
+  /// pass a path of your own when starting more than one, as tests do.
+  String get portFilePath => _portFilePath ?? getLogPortPath();
 
   /// Circular buffer of log entries
   final Queue<LogEntry> _buffer = Queue<LogEntry>();
@@ -181,12 +191,11 @@ class LogServer {
     }
   }
 
-  /// Write port number to global log_port file
+  /// Write port number to the log_port file
   Future<void> _writePortFile() async {
     try {
-      await ensureNoctermDirectoryExists();
-
-      final portFile = File(getLogPortPath());
+      final portFile = File(portFilePath);
+      await portFile.parent.create(recursive: true);
       await portFile.writeAsString('$port');
     } catch (e) {
       stderr.writeln('Warning: Failed to write log_port file: $e');
@@ -221,7 +230,7 @@ class LogServer {
 
     // Clean up port file
     try {
-      final portFile = File(getLogPortPath());
+      final portFile = File(portFilePath);
       if (await portFile.exists()) {
         await portFile.delete();
       }

--- a/lib/src/utils/nocterm_paths.dart
+++ b/lib/src/utils/nocterm_paths.dart
@@ -27,9 +27,17 @@ String getNoctermDirectory() {
   return p.join(home, '.nocterm', projHash);
 }
 
-String getProjectDirectory() {
-  final start = Directory.current.path;
-  var parent = Directory.current;
+/// The closest ancestor of [from] holding a `pubspec.yaml`, or [from]
+/// itself when no ancestor has one.
+///
+/// [from] defaults to the process's current directory. Pass it explicitly
+/// to avoid depending on that: `Directory.current` is process-wide rather
+/// than per-isolate, so a caller that sets it races with every other
+/// isolate in the process.
+String getProjectDirectory({Directory? from}) {
+  final origin = from ?? Directory.current;
+  final start = origin.path;
+  var parent = origin;
   while (true) {
     final pubspec = File(p.join(parent.path, 'pubspec.yaml'));
     if (pubspec.existsSync()) return parent.path;

--- a/test/components/divider_blend_test.dart
+++ b/test/components/divider_blend_test.dart
@@ -267,6 +267,54 @@ void main() {
     });
   });
 
+  group('Given a divider reaching into empty space', () {
+    // Caps are expressed as arms now, but a cap landing on a cell with
+    // nothing to merge into must still paint what it always did.
+    // Inset by one cell so the negative indents reach cells that are on
+    // screen but hold nothing.
+    Future<void> pumpDivider(NoctermTester tester, DividerStyle style) {
+      return tester.pumpComponent(
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 1),
+          child: Column(
+            children: [
+              const SizedBox(height: 1),
+              Divider(indent: -1, endIndent: -1, style: style),
+              Expanded(child: const SizedBox.shrink()),
+            ],
+          ),
+        ),
+      );
+    }
+
+    test('when light then the half-arm stub is kept', () {
+      return testNocterm(
+        'light stub on empty space',
+        (tester) async {
+          await pumpDivider(tester, DividerStyle.single);
+          final state = tester.terminalState;
+          expect(state.getTextAt(0, 1, length: 1), '╶');
+          expect(state.getTextAt(11, 1, length: 1), '╴');
+        },
+        size: const Size(12, 5),
+      );
+    });
+
+    test('when double then the line character is kept', () {
+      return testNocterm(
+        'double fallback on empty space',
+        (tester) async {
+          await pumpDivider(tester, DividerStyle.double);
+          final state = tester.terminalState;
+          // No double half-arm exists, so the end cells stay ═.
+          expect(state.getTextAt(0, 1, length: 1), '═');
+          expect(state.getTextAt(11, 1, length: 1), '═');
+        },
+        size: const Size(12, 5),
+      );
+    });
+  });
+
   test(
       'Given a light divider reaching into a double border '
       'when rendered then it tees into both columns', () {

--- a/test/components/divider_blend_test.dart
+++ b/test/components/divider_blend_test.dart
@@ -166,4 +166,136 @@ void main() {
       size: const Size(12, 7),
     );
   });
+
+  group('Given a double-style divider reaching into a border', () {
+    // Unicode has half lines at light (╴╵╶╷) and heavy (╸╹╺╻) weight only,
+    // so a lone double arm cannot be named by a character - but every
+    // junction it forms can. The end contributes its arm regardless of
+    // whether a glyph exists for the arm alone.
+
+    test('when horizontal into a light border then it tees into both columns',
+        () {
+      return testNocterm(
+        'double horizontal divider tees',
+        (tester) async {
+          await tester.pumpComponent(
+            Container(
+              decoration: BoxDecoration(border: BoxBorder.all()),
+              child: Column(
+                children: [
+                  const SizedBox(height: 2),
+                  const Divider(
+                    indent: -1,
+                    endIndent: -1,
+                    style: DividerStyle.double,
+                  ),
+                  Expanded(child: const SizedBox.shrink()),
+                ],
+              ),
+            ),
+          );
+
+          final state = tester.terminalState;
+          expect(state.getTextAt(0, 3, length: 1), '╞');
+          expect(state.getTextAt(11, 3, length: 1), '╡');
+          expect(state.getTextAt(5, 3, length: 1), '═');
+        },
+        size: const Size(12, 7),
+      );
+    });
+
+    test('when vertical into a light border then it tees into both rows', () {
+      return testNocterm(
+        'double vertical divider tees',
+        (tester) async {
+          await tester.pumpComponent(
+            Container(
+              decoration: BoxDecoration(border: BoxBorder.all()),
+              child: Row(
+                children: [
+                  const SizedBox(width: 3),
+                  const VerticalDivider(
+                    indent: -1,
+                    endIndent: -1,
+                    style: DividerStyle.double,
+                  ),
+                  Expanded(child: const SizedBox.shrink()),
+                ],
+              ),
+            ),
+          );
+
+          final state = tester.terminalState;
+          expect(state.getTextAt(4, 0, length: 1), '╥');
+          expect(state.getTextAt(4, 4, length: 1), '╨');
+          expect(state.getTextAt(4, 2, length: 1), '║');
+        },
+        size: const Size(12, 5),
+      );
+    });
+
+    test('when horizontal into a double border then it tees into both columns',
+        () {
+      return testNocterm(
+        'double divider into double border',
+        (tester) async {
+          await tester.pumpComponent(
+            Container(
+              decoration: BoxDecoration(
+                border: BoxBorder.all(style: BoxBorderStyle.double),
+              ),
+              child: Column(
+                children: [
+                  const SizedBox(height: 2),
+                  const Divider(
+                    indent: -1,
+                    endIndent: -1,
+                    style: DividerStyle.double,
+                  ),
+                  Expanded(child: const SizedBox.shrink()),
+                ],
+              ),
+            ),
+          );
+
+          final state = tester.terminalState;
+          expect(state.getTextAt(0, 3, length: 1), '╠');
+          expect(state.getTextAt(11, 3, length: 1), '╣');
+        },
+        size: const Size(12, 7),
+      );
+    });
+  });
+
+  test(
+      'Given a light divider reaching into a double border '
+      'when rendered then it tees into both columns', () {
+    // The mirror of the cases above, and it already works: the light cap
+    // glyph ╶ exists, so the arm lands correctly on a double border. This
+    // pins down that the gap is specific to double-weight caps.
+    return testNocterm(
+      'light divider into double border',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(style: BoxBorderStyle.double),
+            ),
+            child: Column(
+              children: [
+                const SizedBox(height: 2),
+                const Divider(indent: -1, endIndent: -1),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(0, 3, length: 1), '╟');
+        expect(state.getTextAt(11, 3, length: 1), '╢');
+      },
+      size: const Size(12, 7),
+    );
+  });
 }

--- a/test/components/divider_blend_test.dart
+++ b/test/components/divider_blend_test.dart
@@ -267,9 +267,51 @@ void main() {
     });
   });
 
+  test(
+      'Given a divider reaching into a border title '
+      'when rendered then the title is untouched', () {
+    // A title's letters are not lines, and its padding spaces are holes in
+    // the border run rather than empty canvas - the run is simply absent
+    // there. Neither is the divider's to write, so an end landing on one
+    // contributes nothing. Columns 5 and 8 are the 't' of 'Title' and the
+    // space closing it.
+    return testNocterm(
+      'divider end on a border title',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(),
+              title: const BorderTitle(text: 'Title'),
+            ),
+            child: Row(
+              children: [
+                const SizedBox(width: 4),
+                const VerticalDivider(indent: -1),
+                const SizedBox(width: 2),
+                const VerticalDivider(indent: -1),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(0, 0, length: 16), '┌─ Title ──────┐');
+        // The dividers themselves still paint inside the box.
+        expect(state.getTextAt(5, 1, length: 1), '│');
+        expect(state.getTextAt(8, 1, length: 1), '│');
+      },
+      size: const Size(16, 5),
+    );
+  });
+
   group('Given a divider reaching into empty space', () {
-    // Caps are expressed as arms now, but a cap landing on a cell with
-    // nothing to merge into must still paint what it always did.
+    // An end reaches outside the rule's own bounds to form a junction.
+    // With nothing there to join, the cell is not the rule's to write - a
+    // space is as opaque as any other character. Leaving a half-arm on
+    // spec would put stray marks wherever a cell happened to be blank,
+    // including the padding spaces inside a border title.
     // Inset by one cell so the negative indents reach cells that are on
     // screen but hold nothing.
     Future<void> pumpDivider(NoctermTester tester, DividerStyle style) {
@@ -287,30 +329,95 @@ void main() {
       );
     }
 
-    test('when light then the half-arm stub is kept', () {
+    test('when light then the end cells are left alone', () {
       return testNocterm(
-        'light stub on empty space',
+        'light end on empty space',
         (tester) async {
           await pumpDivider(tester, DividerStyle.single);
           final state = tester.terminalState;
-          expect(state.getTextAt(0, 1, length: 1), '╶');
-          expect(state.getTextAt(11, 1, length: 1), '╴');
+          expect(state.getTextAt(0, 1, length: 1), ' ');
+          expect(state.getTextAt(11, 1, length: 1), ' ');
+          // The rule's own cells are unaffected.
+          expect(state.getTextAt(1, 1, length: 1), '─');
+          expect(state.getTextAt(10, 1, length: 1), '─');
         },
         size: const Size(12, 5),
       );
     });
 
-    test('when double then the line character is kept', () {
+    test('when double then the end cells are left alone', () {
       return testNocterm(
-        'double fallback on empty space',
+        'double end on empty space',
         (tester) async {
           await pumpDivider(tester, DividerStyle.double);
           final state = tester.terminalState;
-          // No double half-arm exists, so the end cells stay ═.
-          expect(state.getTextAt(0, 1, length: 1), '═');
-          expect(state.getTextAt(11, 1, length: 1), '═');
+          expect(state.getTextAt(0, 1, length: 1), ' ');
+          expect(state.getTextAt(11, 1, length: 1), ' ');
+          expect(state.getTextAt(1, 1, length: 1), '═');
         },
         size: const Size(12, 5),
+      );
+    });
+  });
+
+  group('Given a rule ending against a divider', () {
+    // Blending only ever sees what is already in the buffer, so a junction
+    // needs the surface drawn first - the same reason a box's border is
+    // drawn before the dividers that tee into it. Order is expressed with a
+    // Stack because Row siblings paint in child order.
+    Component scene({required bool dividerFirst}) {
+      final rule = Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                const SizedBox(height: 1),
+                const Divider(endIndent: -1, style: DividerStyle.dashed),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+          const SizedBox(width: 1),
+          Expanded(child: const SizedBox.shrink()),
+        ],
+      );
+      final divider = Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(child: const SizedBox.shrink()),
+          const VerticalDivider(style: DividerStyle.double),
+          Expanded(child: const SizedBox.shrink()),
+        ],
+      );
+      return Stack(children: dividerFirst ? [divider, rule] : [rule, divider]);
+    }
+
+    test('when the divider is painted first then the junction forms', () {
+      return testNocterm(
+        'divider first',
+        (tester) async {
+          await tester.pumpComponent(scene(dividerFirst: true));
+          final state = tester.terminalState;
+          expect(state.getTextAt(6, 1, length: 1), '╢');
+          expect(state.getTextAt(6, 0, length: 1), '║');
+        },
+        size: const Size(13, 5),
+      );
+    });
+
+    test('when the rule is painted first then it stops against it', () {
+      // The rule's end lands on a cell that is still empty, and an empty
+      // cell is not the rule's to write, so there is nothing for the
+      // divider to merge with when it arrives.
+      return testNocterm(
+        'rule first',
+        (tester) async {
+          await tester.pumpComponent(scene(dividerFirst: false));
+          final state = tester.terminalState;
+          expect(state.getTextAt(6, 1, length: 1), '║');
+        },
+        size: const Size(13, 5),
       );
     });
   });

--- a/test/components/divider_blend_test.dart
+++ b/test/components/divider_blend_test.dart
@@ -1,0 +1,169 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+/// Dividers reaching into a surrounding border with negative indents must
+/// form tee junctions instead of leaving gaps or overwriting the border.
+void main() {
+  test(
+      'Given a bordered box with a horizontal divider reaching into the '
+      'borders when rendered then it tees into both border columns', () {
+    return testNocterm(
+      'horizontal divider tees',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(border: BoxBorder.all()),
+            child: Column(
+              children: [
+                const SizedBox(height: 2),
+                const Divider(indent: -1, endIndent: -1),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        // Border cols are 0 and 11; content starts at row 1, so the
+        // divider sits on row 3.
+        expect(state.getTextAt(0, 3, length: 1), '├');
+        expect(state.getTextAt(11, 3, length: 1), '┤');
+        expect(state.getTextAt(5, 3, length: 1), '─');
+        // The border away from the junction is untouched.
+        expect(state.getTextAt(0, 2, length: 1), '│');
+      },
+      size: const Size(12, 7),
+    );
+  });
+
+  test(
+      'Given a bordered box with a vertical divider reaching into the '
+      'borders when rendered then it tees into both border rows', () {
+    return testNocterm(
+      'vertical divider tees',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(border: BoxBorder.all()),
+            child: Row(
+              children: [
+                const SizedBox(width: 3),
+                const VerticalDivider(indent: -1, endIndent: -1),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        // Border rows are 0 and 4; content starts at col 1, so the
+        // divider sits on col 4.
+        expect(state.getTextAt(4, 0, length: 1), '┬');
+        expect(state.getTextAt(4, 4, length: 1), '┴');
+        expect(state.getTextAt(4, 2, length: 1), '│');
+        expect(state.getTextAt(3, 0, length: 1), '─');
+      },
+      size: const Size(12, 5),
+    );
+  });
+
+  test(
+      'Given a bordered box with crossing dividers '
+      'when rendered then a cross junction is formed where they intersect', () {
+    return testNocterm(
+      'crossing dividers',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(border: BoxBorder.all()),
+            child: Stack(
+              children: [
+                Column(
+                  children: [
+                    const SizedBox(height: 2),
+                    const Divider(indent: -1, endIndent: -1),
+                    Expanded(child: const SizedBox.shrink()),
+                  ],
+                ),
+                Row(
+                  children: [
+                    const SizedBox(width: 3),
+                    const VerticalDivider(indent: -1, endIndent: -1),
+                    Expanded(child: const SizedBox.shrink()),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(4, 3, length: 1), '┼');
+        expect(state.getTextAt(4, 0, length: 1), '┬');
+        expect(state.getTextAt(0, 3, length: 1), '├');
+      },
+      size: const Size(12, 7),
+    );
+  });
+
+  test(
+      'Given a rounded bordered box with a divider reaching into the '
+      'borders '
+      'when rendered then the corners stay rounded', () {
+    return testNocterm(
+      'rounded corners survive',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(style: BoxBorderStyle.rounded),
+            ),
+            child: Column(
+              children: [
+                const SizedBox(height: 2),
+                const Divider(indent: -1, endIndent: -1),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(0, 3, length: 1), '├');
+        expect(state.getTextAt(0, 0, length: 1), '╭');
+        expect(state.getTextAt(11, 6, length: 1), '╯');
+      },
+      size: const Size(12, 7),
+    );
+  });
+
+  test(
+      'Given a bordered box with a divider that stays within its bounds '
+      'when rendered then the border is untouched', () {
+    return testNocterm(
+      'divider within bounds',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(border: BoxBorder.all()),
+            child: Column(
+              children: [
+                const SizedBox(height: 2),
+                const Divider(),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        // No caps, no junctions: the border column keeps its vertical
+        // line.
+        expect(state.getTextAt(0, 3, length: 1), '│');
+        expect(state.getTextAt(1, 3, length: 1), '─');
+        expect(state.getTextAt(10, 3, length: 1), '─');
+      },
+      size: const Size(12, 7),
+    );
+  });
+}

--- a/test/components/divider_defects_test.dart
+++ b/test/components/divider_defects_test.dart
@@ -134,4 +134,49 @@ void main() {
       size: const Size(12, 7),
     );
   });
+
+  test(
+      'Given a divider whose cap lands on a cell it does not change '
+      'when rendered then that cell keeps its own colour', () {
+    // A cell the merge declines to change is not the divider's to restyle
+    // either - keeping the glyph means keeping the cell.
+    return testNocterm(
+      'kept glyph keeps its colour',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(color: Colors.green),
+            ),
+            child: Stack(
+              children: [
+                Row(
+                  children: [
+                    const SizedBox(width: 3),
+                    const VerticalDivider(indent: -1, color: Colors.green),
+                    Expanded(child: const SizedBox.shrink()),
+                  ],
+                ),
+                Row(
+                  children: [
+                    const SizedBox(width: 3),
+                    const VerticalDivider(indent: -1, color: Colors.red),
+                    Expanded(child: const SizedBox.shrink()),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        // The first divider already formed the tee; the second contributes
+        // an arm that is already there, so the glyph is kept.
+        expect(state.getTextAt(4, 0, length: 1), '┬');
+        // Keeping the glyph should mean keeping the cell, colour included.
+        expect(state.getCellAt(4, 0)?.style.color, Colors.green);
+      },
+      size: const Size(12, 5),
+    );
+  });
 }

--- a/test/components/divider_defects_test.dart
+++ b/test/components/divider_defects_test.dart
@@ -18,7 +18,9 @@ void main() {
           await tester.pumpComponent(
             Row(children: [const Text('hi'), const Divider()]),
           );
-          expect(tester.terminalState.getTextAt(0, 0, length: 2), 'hi');
+          // The binding catches a paint exception by discarding the frame,
+          // so a sibling surviving is what says painting completed.
+          expect(tester.terminalState, containsText('hi'));
         },
         size: const Size(12, 3),
       );
@@ -31,7 +33,7 @@ void main() {
           await tester.pumpComponent(
             Column(children: [const Text('hi'), const VerticalDivider()]),
           );
-          expect(tester.terminalState.getTextAt(0, 0, length: 2), 'hi');
+          expect(tester.terminalState, containsText('hi'));
         },
         size: const Size(12, 3),
       );

--- a/test/components/divider_defects_test.dart
+++ b/test/components/divider_defects_test.dart
@@ -5,6 +5,50 @@ import 'package:test/test.dart';
 /// own geometry: infinite sizes, no extent at all, fractional indents, and
 /// weights with no junction between them.
 void main() {
+  /// Which colour each cell was painted in: `G` green, `R` red, `·` other.
+  ///
+  /// Snapshots carry characters only, so a cell painted the wrong colour is
+  /// invisible in one. This draws the colours instead.
+  List<String> colourMap(TerminalState state, int width, int height) {
+    return [
+      for (var y = 0; y < height; y++)
+        [
+          for (var x = 0; x < width; x++)
+            switch (state.getCellAt(x, y)?.style.color) {
+              Colors.green => 'G',
+              Colors.red => 'R',
+              _ => '·',
+            },
+        ].join(),
+    ];
+  }
+
+  /// The two overlapping dividers used by the recolour tests: a green one
+  /// forms the tee, then a red one contributes an arm already present.
+  Component overlappingDividers() {
+    return Container(
+      decoration: BoxDecoration(border: BoxBorder.all(color: Colors.green)),
+      child: Stack(
+        children: [
+          Row(
+            children: [
+              const SizedBox(width: 3),
+              const VerticalDivider(indent: -1, color: Colors.green),
+              Expanded(child: const SizedBox.shrink()),
+            ],
+          ),
+          Row(
+            children: [
+              const SizedBox(width: 3),
+              const VerticalDivider(indent: -1, color: Colors.red),
+              Expanded(child: const SizedBox.shrink()),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
   group('Given a divider under unbounded main-axis constraints', () {
     // performLayout constrains to Size(double.infinity, height), so an
     // unbounded parent leaves the size infinite, and rounding a non-finite
@@ -145,31 +189,7 @@ void main() {
     return testNocterm(
       'kept glyph keeps its colour',
       (tester) async {
-        await tester.pumpComponent(
-          Container(
-            decoration: BoxDecoration(
-              border: BoxBorder.all(color: Colors.green),
-            ),
-            child: Stack(
-              children: [
-                Row(
-                  children: [
-                    const SizedBox(width: 3),
-                    const VerticalDivider(indent: -1, color: Colors.green),
-                    Expanded(child: const SizedBox.shrink()),
-                  ],
-                ),
-                Row(
-                  children: [
-                    const SizedBox(width: 3),
-                    const VerticalDivider(indent: -1, color: Colors.red),
-                    Expanded(child: const SizedBox.shrink()),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        );
+        await tester.pumpComponent(overlappingDividers());
 
         final state = tester.terminalState;
         // The first divider already formed the tee; the second contributes
@@ -177,6 +197,29 @@ void main() {
         expect(state.getTextAt(4, 0, length: 1), '┬');
         // Keeping the glyph should mean keeping the cell, colour included.
         expect(state.getCellAt(4, 0)?.style.color, Colors.green);
+      },
+      size: const Size(12, 5),
+    );
+  });
+
+  test(
+      'Given a divider whose cap lands on a cell it does not change '
+      'when rendered then only its own cells are red', () {
+    return testNocterm(
+      'kept glyph colour picture',
+      (tester) async {
+        await tester.pumpComponent(overlappingDividers());
+
+        // The red divider owns the three interior cells of its column. The
+        // border row above it merely receives an arm the tee already has,
+        // so it stays part of the green border.
+        expect(colourMap(tester.terminalState, 12, 5), [
+          'GGGGGGGGGGGG',
+          'G···R······G',
+          'G···R······G',
+          'G···R······G',
+          'GGGGGGGGGGGG',
+        ]);
       },
       size: const Size(12, 5),
     );

--- a/test/components/divider_defects_test.dart
+++ b/test/components/divider_defects_test.dart
@@ -1,0 +1,40 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+/// What a divider's blended painting must do at the awkward edges of its
+/// own geometry: infinite sizes, no extent at all, fractional indents, and
+/// weights with no junction between them.
+void main() {
+  group('Given a divider under unbounded main-axis constraints', () {
+    // performLayout constrains to Size(double.infinity, height), so an
+    // unbounded parent leaves the size infinite, and rounding a non-finite
+    // value throws. RenderDecoratedBox._paintDecoration and
+    // TerminalCanvas.fillRect guard the same way.
+
+    test('when horizontal then painting does not throw', () {
+      return testNocterm(
+        'horizontal divider unbounded',
+        (tester) async {
+          await tester.pumpComponent(
+            Row(children: [const Text('hi'), const Divider()]),
+          );
+          expect(tester.terminalState.getTextAt(0, 0, length: 2), 'hi');
+        },
+        size: const Size(12, 3),
+      );
+    });
+
+    test('when vertical then painting does not throw', () {
+      return testNocterm(
+        'vertical divider unbounded',
+        (tester) async {
+          await tester.pumpComponent(
+            Column(children: [const Text('hi'), const VerticalDivider()]),
+          );
+          expect(tester.terminalState.getTextAt(0, 0, length: 2), 'hi');
+        },
+        size: const Size(12, 3),
+      );
+    });
+  });
+}

--- a/test/components/divider_defects_test.dart
+++ b/test/components/divider_defects_test.dart
@@ -70,4 +70,33 @@ void main() {
       size: const Size(12, 7),
     );
   });
+
+  test(
+      'Given a divider with a fractional negative indent '
+      'when rendered then its own first cell keeps the full line', () {
+    // Whether an end reaches outside is decided by the cells it covers,
+    // not by the sign of the indent: an indent in (-0.5, 0) rounds back
+    // onto the divider's own first cell, which is not a cap.
+    return testNocterm(
+      'fractional indent',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(border: BoxBorder.all()),
+            child: Column(
+              children: [
+                const SizedBox(height: 2),
+                const Divider(indent: -0.5),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(1, 3, length: 1), '─');
+      },
+      size: const Size(12, 7),
+    );
+  });
 }

--- a/test/components/divider_defects_test.dart
+++ b/test/components/divider_defects_test.dart
@@ -99,4 +99,39 @@ void main() {
       size: const Size(12, 7),
     );
   });
+
+  test(
+      'Given a heavy divider reaching into a double border '
+      'when rendered then the border survives', () {
+    // Heavy meeting double has no Unicode junction, so the wall keeps its
+    // own character.
+    return testNocterm(
+      'heavy divider into double border',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(style: BoxBorderStyle.double),
+            ),
+            child: Column(
+              children: [
+                const SizedBox(height: 2),
+                const Divider(
+                  indent: -1,
+                  endIndent: -1,
+                  style: DividerStyle.bold,
+                ),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(0, 3, length: 1), '║');
+        expect(state.getTextAt(11, 3, length: 1), '║');
+      },
+      size: const Size(12, 7),
+    );
+  });
 }

--- a/test/components/divider_defects_test.dart
+++ b/test/components/divider_defects_test.dart
@@ -37,4 +37,37 @@ void main() {
       );
     });
   });
+
+  test(
+      'Given a divider with no cells of its own '
+      'when it reaches into a border then nothing is painted', () {
+    // There is no rule for an end to join the border to, so an arm left on
+    // the border would promise a line that does not exist.
+    return testNocterm(
+      'one-cell divider span',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(border: BoxBorder.all()),
+            child: Column(
+              children: [
+                const SizedBox(height: 2),
+                Row(
+                  children: [
+                    const SizedBox(width: 0, child: Divider(indent: -1)),
+                    Expanded(child: const SizedBox.shrink()),
+                  ],
+                ),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(0, 3, length: 1), '│');
+      },
+      size: const Size(12, 7),
+    );
+  });
 }

--- a/test/process/logger_test.dart
+++ b/test/process/logger_test.dart
@@ -3,30 +3,30 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:nocterm/src/utils/log_server.dart';
 import 'package:nocterm/src/utils/logger.dart';
-import 'package:nocterm/src/utils/nocterm_paths.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
   group('LogServer', () {
     late LogServer logServer;
+    late Directory tempDir;
 
+    // Every server gets a port file of its own. The default path is keyed
+    // by process id, so servers started concurrently in one process - which
+    // is every test in this file - would otherwise overwrite and delete
+    // each other's, and each test would read whichever port won the race.
     setUp(() async {
-      logServer = LogServer(maxBufferSize: 100);
+      tempDir = Directory.systemTemp.createTempSync('nocterm_log_test_');
+      logServer = LogServer(
+        maxBufferSize: 100,
+        portFilePath: p.join(tempDir.path, 'log_port'),
+      );
       await logServer.start();
     });
 
     tearDown(() async {
       await logServer.close();
-
-      // Clean up the global nocterm directory after tests
-      try {
-        final noctermDir = Directory(getNoctermDirectory());
-        if (await noctermDir.exists()) {
-          await noctermDir.delete(recursive: true);
-        }
-      } catch (_) {
-        // Ignore cleanup errors
-      }
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
     });
 
     test('starts server and assigns port', () {
@@ -104,8 +104,8 @@ void main() {
       await ws.close();
     });
 
-    test('creates log_port file in global directory', () async {
-      final portFile = File(getLogPortPath());
+    test('creates log_port file', () async {
+      final portFile = File(logServer.portFilePath);
       expect(await portFile.exists(), isTrue);
 
       final portString = await portFile.readAsString();
@@ -113,7 +113,7 @@ void main() {
     });
 
     test('cleans up log_port file on close', () async {
-      final portFile = File(getLogPortPath());
+      final portFile = File(logServer.portFilePath);
       expect(await portFile.exists(), isTrue);
 
       await logServer.close();
@@ -125,9 +125,14 @@ void main() {
   group('Logger', () {
     late LogServer logServer;
     late Logger logger;
+    late Directory tempDir;
 
     setUp(() async {
-      logServer = LogServer(maxBufferSize: 100);
+      tempDir = Directory.systemTemp.createTempSync('nocterm_log_test_');
+      logServer = LogServer(
+        maxBufferSize: 100,
+        portFilePath: p.join(tempDir.path, 'log_port'),
+      );
       await logServer.start();
       logger = Logger(logServer: logServer);
     });
@@ -135,6 +140,7 @@ void main() {
     tearDown(() async {
       await logger.close();
       await logServer.close();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
     });
 
     test('sends logs to server', () {

--- a/test/rendering/border_blend_test.dart
+++ b/test/rendering/border_blend_test.dart
@@ -1,0 +1,107 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+/// A border's corner cells merge with box-drawing characters painted
+/// underneath them, so a panel overlaid on another box tees into its border.
+void main() {
+  test(
+      'Given a bordered panel overlaid on a bordered box '
+      'when rendered then the panel corners tee into the border underneath',
+      () {
+    return testNocterm(
+      'overlay tees into outer border',
+      (tester) async {
+        await tester.pumpComponent(
+          Stack(
+            children: [
+              Positioned.fill(
+                child: Container(
+                  decoration: BoxDecoration(
+                    border: BoxBorder.all(style: BoxBorderStyle.rounded),
+                  ),
+                ),
+              ),
+              Positioned(
+                top: 0,
+                right: 0,
+                bottom: 0,
+                child: SizedBox(
+                  width: 8,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: BoxBorder.all(style: BoxBorderStyle.rounded),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+
+        final state = tester.terminalState;
+        // The panel spans cols 12-19 over the full height; its left edge
+        // lands on the outer box's top and bottom borders.
+        expect(state.getTextAt(12, 0, length: 1), '┬');
+        expect(state.getTextAt(12, 6, length: 1), '┴');
+        // Coincident corners keep their rounded shape.
+        expect(state.getTextAt(19, 0, length: 1), '╮');
+        expect(state.getTextAt(19, 6, length: 1), '╯');
+        expect(state.getTextAt(0, 0, length: 1), '╭');
+        // The panel's own left edge stays a plain line.
+        expect(state.getTextAt(12, 3, length: 1), '│');
+      },
+      size: const Size(20, 7),
+    );
+  });
+
+  test(
+      'Given an overlaid bordered panel with a background color '
+      'when rendered then the background does not erase the border underneath',
+      () {
+    return testNocterm(
+      'background keeps outer border',
+      (tester) async {
+        await tester.pumpComponent(
+          Stack(
+            children: [
+              Positioned.fill(
+                child: Container(
+                  decoration: BoxDecoration(
+                    border: BoxBorder.all(style: BoxBorderStyle.rounded),
+                  ),
+                ),
+              ),
+              Positioned(
+                top: 0,
+                right: 0,
+                bottom: 0,
+                child: SizedBox(
+                  width: 8,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.blue,
+                      border: BoxBorder.all(style: BoxBorderStyle.rounded),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+
+        final state = tester.terminalState;
+        // The background fill stops at the panel's interior, so the border
+        // ring still merges with the outer box underneath.
+        expect(state.getTextAt(12, 0, length: 1), '┬');
+        expect(state.getTextAt(12, 6, length: 1), '┴');
+        expect(state.getTextAt(19, 0, length: 1), '╮');
+        // The interior is filled with the background.
+        expect(
+          state.getCellAt(15, 3)?.style.backgroundColor,
+          Colors.blue,
+        );
+      },
+      size: const Size(20, 7),
+    );
+  });
+}

--- a/test/rendering/decoration_inset_test.dart
+++ b/test/rendering/decoration_inset_test.dart
@@ -109,4 +109,35 @@ void main() {
       size: const Size(12, 5),
     );
   });
+
+  test(
+      'Given a dotted border with a light divider '
+      'when they meet then the junction matches the border weight', () {
+    // A dotted border's edges and corners carry the same weight, so a light
+    // divider meets them at that weight rather than a heavier one.
+    return testNocterm(
+      'dotted border junction weight',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(style: BoxBorderStyle.dotted),
+            ),
+            child: Column(
+              children: [
+                const SizedBox(height: 1),
+                const Divider(indent: -1, endIndent: -1),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(0, 2, length: 1), '├');
+        expect(state.getTextAt(11, 2, length: 1), '┤');
+      },
+      size: const Size(12, 5),
+    );
+  });
 }

--- a/test/rendering/decoration_inset_test.dart
+++ b/test/rendering/decoration_inset_test.dart
@@ -69,4 +69,44 @@ void main() {
       size: const Size(12, 5),
     );
   });
+
+  test(
+      'Given a titled bordered box with a background '
+      'when the title has its own style then it keeps the background', () {
+    // The title paints on the border row, which the inset fill does not
+    // cover, so a title style with no backgroundColor of its own takes
+    // whatever is underneath the panel.
+    return testNocterm(
+      'title keeps panel background',
+      (tester) async {
+        await tester.pumpComponent(
+          Stack(
+            children: [
+              Container(
+                decoration: const BoxDecoration(color: Colors.red),
+                child: const SizedBox(width: 12, height: 5),
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.blue,
+                  border: BoxBorder.all(),
+                  title: const BorderTitle(
+                    text: 'Hi',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+                child: const SizedBox(width: 10, height: 3),
+              ),
+            ],
+          ),
+        );
+
+        final state = tester.terminalState;
+        final titleX = state.getText().split('\n').first.indexOf('H');
+        expect(titleX, greaterThan(0), reason: 'title should be rendered');
+        expect(state.getCellAt(titleX, 0)?.style.backgroundColor, Colors.blue);
+      },
+      size: const Size(12, 5),
+    );
+  });
 }

--- a/test/rendering/decoration_inset_test.dart
+++ b/test/rendering/decoration_inset_test.dart
@@ -192,6 +192,42 @@ void main() {
   });
 
   test(
+      'Given a bold border with a light divider '
+      'when they meet then the junction keeps both weights', () {
+    // The one direction the other styles cannot produce: a light arm
+    // landing on a heavy wall, which keeps the wall heavy and the arm
+    // light rather than picking one.
+    return testNocterm(
+      'bold border junctions',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              border: BoxBorder.all(style: BoxBorderStyle.bold),
+            ),
+            child: Column(
+              children: [
+                const SizedBox(height: 1),
+                const Divider(indent: -1, endIndent: -1),
+                Expanded(child: const SizedBox.shrink()),
+              ],
+            ),
+          ),
+        );
+
+        final state = tester.terminalState;
+        expect(state.getTextAt(0, 2, length: 1), '┠');
+        expect(state.getTextAt(11, 2, length: 1), '┨');
+        // The border itself is heavy throughout.
+        expect(state.getTextAt(0, 0, length: 1), '┏');
+        expect(state.getTextAt(11, 4, length: 1), '┛');
+        expect(state.getTextAt(5, 0, length: 1), '━');
+      },
+      size: const Size(12, 5),
+    );
+  });
+
+  test(
       'Given a dotted border with a light divider '
       'when they meet then the junction matches the border weight', () {
     // A dotted border's edges and corners carry the same weight, so a light

--- a/test/rendering/decoration_inset_test.dart
+++ b/test/rendering/decoration_inset_test.dart
@@ -1,0 +1,42 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+/// The background fill is inset by one cell on every non-none border side
+/// so it cannot erase a border it should be merging with. Every cell of the
+/// box still has to be painted by one pass or the other.
+void main() {
+  test(
+      'Given a box with vertical borders but no top or bottom '
+      'when rendered then the whole column keeps the background', () {
+    // _paintBorder paints a vertical side only for rows strictly between
+    // top and bottom, so with top/bottom none the first and last cells of
+    // the left and right columns are covered by neither pass.
+    return testNocterm(
+      'vertical-only border background',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              color: Colors.blue,
+              border: const BoxBorder(
+                left: BorderSide(),
+                right: BorderSide(),
+                top: BorderSide(),
+              ),
+            ),
+            child: const SizedBox.shrink(),
+          ),
+        );
+
+        final state = tester.terminalState;
+        // The box fills the 12x5 terminal. Row 4 is its last row, and with
+        // no bottom border the vertical sides stop short of it, so its two
+        // end cells are covered by neither the fill nor the border pass.
+        expect(state.getCellAt(6, 4)?.style.backgroundColor, Colors.blue);
+        expect(state.getCellAt(0, 4)?.style.backgroundColor, Colors.blue);
+        expect(state.getCellAt(11, 4)?.style.backgroundColor, Colors.blue);
+      },
+      size: const Size(12, 5),
+    );
+  });
+}

--- a/test/rendering/decoration_inset_test.dart
+++ b/test/rendering/decoration_inset_test.dart
@@ -5,6 +5,21 @@ import 'package:test/test.dart';
 /// so it cannot erase a border it should be merging with. Every cell of the
 /// box still has to be painted by one pass or the other.
 void main() {
+  /// Where the decoration painted a background: `#` filled, `·` bare.
+  ///
+  /// Snapshots carry characters only, so an unpainted cell is invisible in
+  /// one - it holds a space either way. This draws the coverage itself, so
+  /// a hole in the fill shows up as a hole in the picture.
+  List<String> backgroundMap(TerminalState state, int width, int height) {
+    return [
+      for (var y = 0; y < height; y++)
+        [
+          for (var x = 0; x < width; x++)
+            state.getCellAt(x, y)?.style.backgroundColor == null ? '·' : '#',
+        ].join(),
+    ];
+  }
+
   test(
       'Given a box with vertical borders but no top or bottom '
       'when rendered then the whole column keeps the background', () {
@@ -41,6 +56,38 @@ void main() {
   });
 
   test(
+      'Given a box with vertical borders but no top or bottom '
+      'when rendered then its background covers every cell', () {
+    return testNocterm(
+      'vertical-only border background picture',
+      (tester) async {
+        await tester.pumpComponent(
+          Container(
+            decoration: BoxDecoration(
+              color: Colors.blue,
+              border: const BoxBorder(
+                left: BorderSide(),
+                right: BorderSide(),
+                top: BorderSide(),
+              ),
+            ),
+            child: const SizedBox.shrink(),
+          ),
+        );
+
+        expect(backgroundMap(tester.terminalState, 12, 5), [
+          '############',
+          '############',
+          '############',
+          '############',
+          '############',
+        ]);
+      },
+      size: const Size(12, 5),
+    );
+  });
+
+  test(
       'Given an opaque box with only a left border '
       'when drawn over content then nothing shows through', () {
     return testNocterm(
@@ -65,6 +112,40 @@ void main() {
         // Top and bottom cells of the left border column.
         expect(state.getCellAt(0, 0)?.style.backgroundColor, Colors.blue);
         expect(state.getCellAt(0, 2)?.style.backgroundColor, Colors.blue);
+      },
+      size: const Size(12, 5),
+    );
+  });
+
+  test(
+      'Given an opaque box with only a left border '
+      'when drawn over content then its background covers every cell', () {
+    return testNocterm(
+      'left-only border background picture',
+      (tester) async {
+        await tester.pumpComponent(
+          Stack(
+            children: [
+              const Text('XXXXXXXXXXXX\nXXXXXXXXXXXX\nXXXXXXXXXXXX'),
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.blue,
+                  border: const BoxBorder(left: BorderSide()),
+                ),
+                child: const SizedBox(width: 6, height: 3),
+              ),
+            ],
+          ),
+        );
+
+        // The box is 8 wide; the four columns beyond it stay bare.
+        expect(backgroundMap(tester.terminalState, 12, 5), [
+          '########····',
+          '########····',
+          '########····',
+          '########····',
+          '########····',
+        ]);
       },
       size: const Size(12, 5),
     );

--- a/test/rendering/decoration_inset_test.dart
+++ b/test/rendering/decoration_inset_test.dart
@@ -39,4 +39,34 @@ void main() {
       size: const Size(12, 5),
     );
   });
+
+  test(
+      'Given an opaque box with only a left border '
+      'when drawn over content then nothing shows through', () {
+    return testNocterm(
+      'left-only border is opaque',
+      (tester) async {
+        await tester.pumpComponent(
+          Stack(
+            children: [
+              const Text('XXXXXXXXXXXX\nXXXXXXXXXXXX\nXXXXXXXXXXXX'),
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.blue,
+                  border: const BoxBorder(left: BorderSide()),
+                ),
+                child: const SizedBox(width: 6, height: 3),
+              ),
+            ],
+          ),
+        );
+
+        final state = tester.terminalState;
+        // Top and bottom cells of the left border column.
+        expect(state.getCellAt(0, 0)?.style.backgroundColor, Colors.blue);
+        expect(state.getCellAt(0, 2)?.style.backgroundColor, Colors.blue);
+      },
+      size: const Size(12, 5),
+    );
+  });
 }

--- a/test/utils/box_line_merging_test.dart
+++ b/test/utils/box_line_merging_test.dart
@@ -176,6 +176,22 @@ void main() {
   });
 
   test(
+      'Given an arm set with aliases '
+      'when resolved through the reverse lookup '
+      'then the canonical character wins', () {
+    // _armsToChar keeps the first entry per arm set, so the canonical
+    // solid/square character must precede its aliases in _charToArms.
+    // These merges go through that lookup rather than an early return, so
+    // they are what actually pins the ordering down: reorder the map so
+    // '╭' precedes '┌' and only these fail.
+    expect(mergeBoxCharacters('╶', '╷'), '┌');
+    expect(mergeBoxCharacters('╴', '╷'), '┐');
+    expect(mergeBoxCharacters('╶', '╵'), '└');
+    expect(mergeBoxCharacters('╶', '╴'), '─');
+    expect(mergeBoxCharacters('╵', '╷'), '│');
+  });
+
+  test(
       'Given a double line and a light line '
       'when merged then a double-single junction is formed', () {
     expect(mergeBoxCharacters('═', '│'), '╪');

--- a/test/utils/box_line_merging_test.dart
+++ b/test/utils/box_line_merging_test.dart
@@ -266,20 +266,4 @@ void main() {
     // Diagonals are deliberately not mergeable.
     expect(mergeBoxCharacters('╱', '─'), isNull);
   });
-
-  test(
-      'Given box-drawing line characters '
-      'when checked for mergeability then they are mergeable', () {
-    for (final char in ['─', '│', '━', '║', '┼', '╋', '╬', '╴', '╭']) {
-      expect(isMergeableBoxCharacter(char), isTrue, reason: char);
-    }
-  });
-
-  test(
-      'Given non-line characters '
-      'when checked for mergeability then they are not mergeable', () {
-    for (final char in [' ', 'a', '╳', '█', '▸']) {
-      expect(isMergeableBoxCharacter(char), isFalse, reason: char);
-    }
-  });
 }

--- a/test/utils/box_line_merging_test.dart
+++ b/test/utils/box_line_merging_test.dart
@@ -72,6 +72,109 @@ void main() {
     expect(mergeBoxCharacters('╹', '─'), '┸');
   });
 
+  group('Given two characters of the same weight', () {
+    // Same weight means overlapping arms agree, so `pick` returns the same
+    // arm set either way round.
+    const light = [
+      '─', '│', '┌', '┐', '└', '┘', '├', '┤', '┬', '┴', '┼', //
+      '╴', '╵', '╶', '╷',
+    ];
+    const heavy = [
+      '━', '┃', '┏', '┓', '┗', '┛', '┣', '┫', '┳', '┻', '╋', //
+      '╸', '╹', '╺', '╻',
+    ];
+    const double = ['═', '║', '╔', '╗', '╚', '╝', '╠', '╣', '╦', '╩', '╬'];
+
+    for (final (name, chars) in [
+      ('light', light),
+      ('heavy', heavy),
+      ('double', double),
+    ]) {
+      test(
+          'when any two $name characters are merged '
+          'then the order does not matter', () {
+        for (final a in chars) {
+          for (final b in chars) {
+            expect(
+              mergeBoxCharacters(a, b),
+              mergeBoxCharacters(b, a),
+              reason: 'merging $a and $b is order dependent',
+            );
+          }
+        }
+      });
+    }
+  });
+
+  group('Given characters of different weights', () {
+    test(
+        'when their arms point in different directions '
+        'then the order does not matter', () {
+      // The common junction case: a heavy line crossing or landing on a
+      // light one. Neither character has an arm the other also has, so
+      // both weights survive regardless of who is drawn first.
+      for (final (a, b) in [
+        ('┃', '─'),
+        ('━', '│'),
+        ('╻', '─'),
+        ('╹', '─'),
+        ('╺', '│'),
+        ('╷', '━'),
+        ('╶', '┃'),
+        ('║', '─'),
+        ('═', '│'),
+      ]) {
+        expect(
+          mergeBoxCharacters(a, b),
+          mergeBoxCharacters(b, a),
+          reason: 'merging $a and $b is order dependent',
+        );
+      }
+    });
+
+    test(
+        'when they share an arm direction '
+        'then the newly drawn weight wins', () {
+      // Overlapping arms are the one place drawing order is visible: the
+      // new character's weight replaces the existing one on the shared
+      // arm, so heavy-on-light and light-on-heavy differ.
+      expect(mergeBoxCharacters('━', '─'), '━');
+      expect(mergeBoxCharacters('─', '━'), '─');
+      expect(mergeBoxCharacters('┃', '│'), '┃');
+      expect(mergeBoxCharacters('│', '┃'), '│');
+      expect(mergeBoxCharacters('═', '─'), '═');
+      expect(mergeBoxCharacters('─', '═'), '─');
+
+      // The same rule downgrades individual arms of a junction. A light
+      // divider running through a heavy tee thins the arms it overlaps
+      // while leaving the others heavy.
+      expect(mergeBoxCharacters('┝', '─'), '┾');
+      expect(mergeBoxCharacters('─', '┝'), '┼');
+      expect(mergeBoxCharacters('┗', '─'), '┺');
+      expect(mergeBoxCharacters('─', '┗'), '┸');
+      expect(mergeBoxCharacters('┳', '│'), '╈');
+      expect(mergeBoxCharacters('│', '┳'), '┿');
+    });
+
+    test(
+        'when the combination has no Unicode junction '
+        'then each order keeps its own new character', () {
+      // Double never combines with heavy, so the fallback to `newChar`
+      // makes the result depend on which was drawn last.
+      expect(mergeBoxCharacters('═', '┃'), '═');
+      expect(mergeBoxCharacters('┃', '═'), '┃');
+    });
+  });
+
+  test(
+      'Given two aliases with identical arms '
+      'when merged then the existing character is kept', () {
+    // Both orders leave the arms unchanged, so each keeps whichever style
+    // was already on the canvas.
+    expect(mergeBoxCharacters('╭', '┌'), '┌');
+    expect(mergeBoxCharacters('┌', '╭'), '╭');
+  });
+
   test(
       'Given a double line and a light line '
       'when merged then a double-single junction is formed', () {

--- a/test/utils/box_line_merging_test.dart
+++ b/test/utils/box_line_merging_test.dart
@@ -172,8 +172,9 @@ void main() {
     // Nothing about the junction changes, so this is purely a question of
     // which style is on top - and the character being drawn is on top.
     expect(mergeBoxCharacters('╭', '┌'), '╭');
-    expect(mergeBoxCharacters('┌', '╭'), '╭');
+    expect(mergeBoxCharacters('┌', '╭'), '┌');
     expect(mergeBoxCharacters('╌', '─'), '╌');
+    expect(mergeBoxCharacters('─', '╌'), '─');
   });
 
   test(

--- a/test/utils/box_line_merging_test.dart
+++ b/test/utils/box_line_merging_test.dart
@@ -243,11 +243,6 @@ void main() {
       expect(mergeArmsIntoCharacter(doubleDown, '═'), '╦');
     });
 
-    test('when looked up as a character then there is none', () {
-      expect(boxCharacterForArms(doubleRight), isNull);
-      expect(boxCharacterForArms(doubleDown), isNull);
-    });
-
     test('when the arms are already present then the character is unchanged',
         () {
       expect(mergeArmsIntoCharacter(doubleRight, '╠'), '╠');
@@ -259,20 +254,6 @@ void main() {
       expect(mergeArmsIntoCharacter(doubleRight, 'a'), isNull);
       expect(mergeArmsIntoCharacter(doubleRight, ' '), isNull);
     });
-  });
-
-  test(
-      'Given arms that do have a glyph '
-      'when looked up then the canonical character is returned', () {
-    const none = LineArm.none;
-    expect(boxCharacterForArms((none, LineArm.light, none, none)), '╶');
-    expect(boxCharacterForArms((none, LineArm.heavy, none, none)), '╺');
-    expect(
-      boxCharacterForArms(
-        (LineArm.light, LineArm.light, LineArm.light, LineArm.light),
-      ),
-      '┼',
-    );
   });
 
   test(

--- a/test/utils/box_line_merging_test.dart
+++ b/test/utils/box_line_merging_test.dart
@@ -168,11 +168,24 @@ void main() {
 
   test(
       'Given two aliases with identical arms '
-      'when merged then the existing character is kept', () {
-    // Both orders leave the arms unchanged, so each keeps whichever style
-    // was already on the canvas.
-    expect(mergeBoxCharacters('╭', '┌'), '┌');
+      'when merged then the newly drawn style wins', () {
+    // Nothing about the junction changes, so this is purely a question of
+    // which style is on top - and the character being drawn is on top.
+    expect(mergeBoxCharacters('╭', '┌'), '╭');
     expect(mergeBoxCharacters('┌', '╭'), '╭');
+    expect(mergeBoxCharacters('╌', '─'), '╌');
+  });
+
+  test(
+      'Given a character whose arms are a strict subset of the existing one '
+      'when merged then the existing character is kept', () {
+    // The counterpart to the test above, and the case the early return is
+    // there for: a stub landing on a rounded corner must not square it.
+    // Distinguishing the two is what makes both work - keep the existing
+    // character only when the new one contributes strictly less.
+    expect(mergeBoxCharacters('╶', '╭'), '╭');
+    expect(mergeBoxCharacters('╷', '╭'), '╭');
+    expect(mergeBoxCharacters('╶', '┬'), '┬');
   });
 
   test(

--- a/test/utils/box_line_merging_test.dart
+++ b/test/utils/box_line_merging_test.dart
@@ -1,0 +1,123 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a half-arm segment end and a perpendicular full line', () {
+    test('when merged then a tee junction is formed', () {
+      // A divider endpoint contributes only the arm pointing into the
+      // segment, so an endpoint on a border forms a tee, not a cross.
+      expect(mergeBoxCharacters('╷', '─'), '┬');
+      expect(mergeBoxCharacters('╵', '─'), '┴');
+      expect(mergeBoxCharacters('╶', '│'), '├');
+      expect(mergeBoxCharacters('╴', '│'), '┤');
+    });
+
+    test('when merged in either order then the result is the same', () {
+      expect(mergeBoxCharacters('╴', '│'), mergeBoxCharacters('│', '╴'));
+      expect(mergeBoxCharacters('╷', '─'), mergeBoxCharacters('─', '╷'));
+    });
+  });
+
+  test(
+      'Given two perpendicular full lines '
+      'when merged then a cross junction is formed', () {
+    expect(mergeBoxCharacters('│', '─'), '┼');
+    expect(mergeBoxCharacters('─', '│'), '┼');
+  });
+
+  group('Given an existing tee junction', () {
+    test('when a half-arm it already contains is merged then it is unchanged',
+        () {
+      expect(mergeBoxCharacters('╷', '┬'), '┬');
+    });
+
+    test('when a perpendicular full line is merged then it becomes a cross',
+        () {
+      expect(mergeBoxCharacters('│', '┬'), '┼');
+      expect(mergeBoxCharacters('─', '├'), '┼');
+    });
+  });
+
+  group('Given a rounded corner', () {
+    test('when overdrawn with a subset of its arms then it stays rounded', () {
+      expect(mergeBoxCharacters('╶', '╭'), '╭');
+      expect(mergeBoxCharacters('╷', '╭'), '╭');
+      expect(mergeBoxCharacters('╭', '╭'), '╭');
+      expect(mergeBoxCharacters('╴', '╮'), '╮');
+      expect(mergeBoxCharacters('╵', '╰'), '╰');
+    });
+
+    test('when a new arm is added then it becomes a square junction', () {
+      expect(mergeBoxCharacters('╴', '╭'), '┬');
+      expect(mergeBoxCharacters('╵', '╭'), '├');
+    });
+  });
+
+  test(
+      'Given a corner and a full line '
+      'when merged then a tee junction is formed', () {
+    // The overlaid-panel case: a panel corner landing on a border run.
+    expect(mergeBoxCharacters('╭', '─'), '┬');
+    expect(mergeBoxCharacters('╰', '─'), '┴');
+    expect(mergeBoxCharacters('╭', '│'), '├');
+    expect(mergeBoxCharacters('┐', '│'), '┤');
+  });
+
+  test(
+      'Given a heavy line and a light line '
+      'when merged then a mixed-weight junction is formed', () {
+    expect(mergeBoxCharacters('━', '│'), '┿');
+    expect(mergeBoxCharacters('┃', '─'), '╂');
+    expect(mergeBoxCharacters('╺', '│'), '┝');
+    expect(mergeBoxCharacters('╹', '─'), '┸');
+  });
+
+  test(
+      'Given a double line and a light line '
+      'when merged then a double-single junction is formed', () {
+    expect(mergeBoxCharacters('═', '│'), '╪');
+    expect(mergeBoxCharacters('║', '─'), '╫');
+    expect(mergeBoxCharacters('│', '═'), '╪');
+  });
+
+  test(
+      'Given a dashed line and a perpendicular line '
+      'when merged then the junction matches the solid counterpart', () {
+    expect(mergeBoxCharacters('╌', '│'), '┼');
+    expect(mergeBoxCharacters('┊', '─'), '┼');
+  });
+
+  test(
+      'Given a combination with no Unicode representation '
+      'when merged then the new character is kept', () {
+    // Double meeting heavy has no Unicode junction.
+    expect(mergeBoxCharacters('═', '┃'), '═');
+  });
+
+  test(
+      'Given a non box-drawing character '
+      'when merged then no merge is performed', () {
+    expect(mergeBoxCharacters('a', '─'), isNull);
+    expect(mergeBoxCharacters('─', 'a'), isNull);
+    expect(mergeBoxCharacters('─', ' '), isNull);
+    expect(mergeBoxCharacters(' ', ' '), isNull);
+    // Diagonals are deliberately not mergeable.
+    expect(mergeBoxCharacters('╱', '─'), isNull);
+  });
+
+  test(
+      'Given box-drawing line characters '
+      'when checked for mergeability then they are mergeable', () {
+    for (final char in ['─', '│', '━', '║', '┼', '╋', '╬', '╴', '╭']) {
+      expect(isMergeableBoxCharacter(char), isTrue, reason: char);
+    }
+  });
+
+  test(
+      'Given non-line characters '
+      'when checked for mergeability then they are not mergeable', () {
+    for (final char in [' ', 'a', '╳', '█', '▸']) {
+      expect(isMergeableBoxCharacter(char), isFalse, reason: char);
+    }
+  });
+}

--- a/test/utils/box_line_merging_test.dart
+++ b/test/utils/box_line_merging_test.dart
@@ -197,6 +197,54 @@ void main() {
     expect(mergeBoxCharacters('═', '┃'), '═');
   });
 
+  group('Given an arm combination with no standalone glyph', () {
+    const none = LineArm.none;
+    const dbl = LineArm.double;
+    // (up, right, down, left)
+    const doubleRight = (none, dbl, none, none);
+    const doubleDown = (none, none, dbl, none);
+
+    test('when merged into a line then the junction is still formed', () {
+      // Unicode has no double half-line, so these arms cannot be routed
+      // through mergeBoxCharacters at all - but every junction exists.
+      expect(mergeArmsIntoCharacter(doubleRight, '│'), '╞');
+      expect(mergeArmsIntoCharacter(doubleDown, '─'), '╥');
+      expect(mergeArmsIntoCharacter(doubleRight, '║'), '╠');
+      expect(mergeArmsIntoCharacter(doubleDown, '═'), '╦');
+    });
+
+    test('when looked up as a character then there is none', () {
+      expect(boxCharacterForArms(doubleRight), isNull);
+      expect(boxCharacterForArms(doubleDown), isNull);
+    });
+
+    test('when the arms are already present then the character is unchanged',
+        () {
+      expect(mergeArmsIntoCharacter(doubleRight, '╠'), '╠');
+      expect(mergeArmsIntoCharacter(doubleRight, '╬'), '╬');
+    });
+
+    test('when merged into a non box-drawing character then no merge happens',
+        () {
+      expect(mergeArmsIntoCharacter(doubleRight, 'a'), isNull);
+      expect(mergeArmsIntoCharacter(doubleRight, ' '), isNull);
+    });
+  });
+
+  test(
+      'Given arms that do have a glyph '
+      'when looked up then the canonical character is returned', () {
+    const none = LineArm.none;
+    expect(boxCharacterForArms((none, LineArm.light, none, none)), '╶');
+    expect(boxCharacterForArms((none, LineArm.heavy, none, none)), '╺');
+    expect(
+      boxCharacterForArms(
+        (LineArm.light, LineArm.light, LineArm.light, LineArm.light),
+      ),
+      '┼',
+    );
+  });
+
   test(
       'Given a non box-drawing character '
       'when merged then no merge is performed', () {

--- a/test/utils/nocterm_paths_test.dart
+++ b/test/utils/nocterm_paths_test.dart
@@ -7,22 +7,18 @@ import 'package:test/test.dart';
 void main() {
   group('getProjectDirectory', () {
     late Directory tempRoot;
-    late Directory previousCwd;
 
+    // Each test walks up from a directory it passes in rather than from the
+    // process's current one. `Directory.current` is process-wide and not
+    // per-isolate, so setting it here would race with every other test
+    // running concurrently in the same process - including tests in other
+    // files, which would then resolve their own relative paths against
+    // whichever temp directory happened to win.
     setUp(() {
-      previousCwd = Directory.current;
-      // Resolve symlinks up front: macOS maps /tmp -> /private/tmp (and
-      // /var -> /private/var), but getProjectDirectory() reads
-      // Directory.current.path, which the OS canonicalizes. Without this the
-      // expected paths keep the symlink prefix and the actual paths don't,
-      // so every assertion fails on macOS (Linux CI has no such symlink).
-      tempRoot = Directory(Directory.systemTemp
-          .createTempSync('nocterm_paths_test_')
-          .resolveSymbolicLinksSync());
+      tempRoot = Directory.systemTemp.createTempSync('nocterm_paths_test_');
     });
 
     tearDown(() {
-      Directory.current = previousCwd;
       if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
     });
 
@@ -31,25 +27,32 @@ void main() {
       File(p.join(project.path, 'pubspec.yaml')).writeAsStringSync('name: x');
       final nested = Directory(p.join(project.path, 'a', 'b'))
         ..createSync(recursive: true);
-      Directory.current = nested;
 
-      expect(getProjectDirectory(), equals(project.path));
+      expect(getProjectDirectory(from: nested), equals(project.path));
     });
 
-    test('returns cwd when no pubspec.yaml ancestor exists', () {
+    test('returns the starting directory when no pubspec.yaml ancestor exists',
+        () {
       final dir = Directory(p.join(tempRoot.path, 'a', 'b', 'c'))
         ..createSync(recursive: true);
-      Directory.current = dir;
 
-      expect(getProjectDirectory(), equals(dir.path));
+      expect(getProjectDirectory(from: dir), equals(dir.path));
     });
 
     test('terminates when walking past the filesystem root', () {
       final dir = Directory(p.join(tempRoot.path, 'deep', 'no', 'project'))
         ..createSync(recursive: true);
-      Directory.current = dir;
 
-      expect(getProjectDirectory(), equals(dir.path));
+      expect(getProjectDirectory(from: dir), equals(dir.path));
+    });
+
+    test('defaults to the current directory', () {
+      // The default path still has to work - this project has a pubspec.
+      expect(getProjectDirectory(), isNotEmpty);
+      expect(
+        File(p.join(getProjectDirectory(), 'pubspec.yaml')).existsSync(),
+        isTrue,
+      );
     });
   });
 }

--- a/test/visual/box_line_blending_visual_test.dart
+++ b/test/visual/box_line_blending_visual_test.dart
@@ -90,19 +90,17 @@ void main() {
   });
 
   test('A light divider tees into a dotted border', () {
-    // The dotted style's edges are heavy while its corners are light, so
-    // the junctions currently render ┠ ┨ - bolder than the box itself.
     return expectBox(
       boxWith(
         const Divider(indent: -1, endIndent: -1),
         style: BoxBorderStyle.dotted,
       ),
       [
-        '┌┅┅┅┅┅┅┅┅┅┅┅┅┐',
-        '┇············┇',
+        '┌┄┄┄┄┄┄┄┄┄┄┄┄┐',
+        '┆············┆',
         '├────────────┤',
-        '┇············┇',
-        '└┅┅┅┅┅┅┅┅┅┅┅┅┘',
+        '┆············┆',
+        '└┄┄┄┄┄┄┄┄┄┄┄┄┘',
       ],
     );
   });

--- a/test/visual/box_line_blending_visual_test.dart
+++ b/test/visual/box_line_blending_visual_test.dart
@@ -1,0 +1,147 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+/// Box-line blending, shown rather than described.
+///
+/// Each test states the whole box as it should look. On failure the matcher
+/// prints the expected and actual pictures one above the other, so a broken
+/// junction is visible at a glance instead of being spelled out one cell at
+/// a time. (`·` is an empty cell.)
+///
+/// The character-level assertions live beside these in
+/// test/components/divider_defects_test.dart and
+/// test/utils/box_line_merging_test.dart.
+void main() {
+  /// A bordered box with [child] on its middle row.
+  Component boxWith(
+    Component child, {
+    BoxBorderStyle style = BoxBorderStyle.solid,
+  }) {
+    return Container(
+      decoration: BoxDecoration(border: BoxBorder.all(style: style)),
+      child: Column(
+        children: [
+          const SizedBox(height: 1),
+          child,
+          Expanded(child: const SizedBox.shrink()),
+        ],
+      ),
+    );
+  }
+
+  Matcher looksLike(List<String> picture) =>
+      matchesSnapshot(picture.join('\n'));
+
+  Future<void> expectBox(Component component, List<String> picture) {
+    return testNocterm(
+      'box line blending',
+      (tester) async {
+        await tester.pumpComponent(component);
+        expect(tester.terminalState, looksLike(picture));
+      },
+      size: const Size(14, 5),
+    );
+  }
+
+  test('A light divider tees into a light border', () {
+    return expectBox(
+      boxWith(const Divider(indent: -1, endIndent: -1)),
+      [
+        '┌────────────┐',
+        '│············│',
+        '├────────────┤',
+        '│············│',
+        '└────────────┘',
+      ],
+    );
+  });
+
+  test('A double divider tees into a light border', () {
+    return expectBox(
+      boxWith(
+        const Divider(indent: -1, endIndent: -1, style: DividerStyle.double),
+      ),
+      [
+        '┌────────────┐',
+        '│············│',
+        '╞════════════╡',
+        '│············│',
+        '└────────────┘',
+      ],
+    );
+  });
+
+  test('A heavy divider leaves a double border intact', () {
+    // Heavy meeting double has no junction glyph, so the end contributes
+    // nothing and the wall stays whole rather than gaining two holes.
+    return expectBox(
+      boxWith(
+        const Divider(indent: -1, endIndent: -1, style: DividerStyle.bold),
+        style: BoxBorderStyle.double,
+      ),
+      [
+        '╔════════════╗',
+        '║············║',
+        '║━━━━━━━━━━━━║',
+        '║············║',
+        '╚════════════╝',
+      ],
+    );
+  });
+
+  test('A light divider tees into a dotted border', () {
+    // The dotted style's edges are heavy while its corners are light, so
+    // the junctions currently render ┠ ┨ - bolder than the box itself.
+    return expectBox(
+      boxWith(
+        const Divider(indent: -1, endIndent: -1),
+        style: BoxBorderStyle.dotted,
+      ),
+      [
+        '┌┅┅┅┅┅┅┅┅┅┅┅┅┐',
+        '┇············┇',
+        '├────────────┤',
+        '┇············┇',
+        '└┅┅┅┅┅┅┅┅┅┅┅┅┘',
+      ],
+    );
+  });
+
+  test('A divider with a fractional indent draws an unbroken line', () {
+    // Whether an end reaches outside comes from the cells the run covers,
+    // not the sign of the indent: -0.5 rounds back onto the divider's own
+    // first cell, which is not an end.
+    return expectBox(
+      boxWith(const Divider(indent: -0.5)),
+      [
+        '┌────────────┐',
+        '│············│',
+        '│────────────│',
+        '│············│',
+        '└────────────┘',
+      ],
+    );
+  });
+
+  test('A divider with no cells of its own leaves the border alone', () {
+    // With no rule to join, an arm on the border would promise a line that
+    // is not there.
+    return expectBox(
+      boxWith(
+        Row(
+          children: [
+            const SizedBox(width: 0, child: Divider(indent: -1)),
+            Expanded(child: const SizedBox.shrink()),
+          ],
+        ),
+      ),
+      [
+        '┌────────────┐',
+        '│············│',
+        '│············│',
+        '│············│',
+        '└────────────┘',
+      ],
+    );
+  });
+}


### PR DESCRIPTION
Borders and dividers previously painted their cells independently, so a divider ending at a border stopped one cell short or overwrote it, the UI showed gaps where ├ ┤ ┬ ┴ ┼ junctions belong.

## What this does
Adds arm-based box-character merging (the approach ratatui/tview use): every char in U+2500–257F maps to four arms with weights, drawing one line char onto another ORs the arms and emits the junction glyph.

- `mergeBoxCharacters()` + `isMergeableBoxCharacter()` in `lib/src/utils/box_line_merging.dart`, exported from `nocterm.dart`
- `TerminalCanvas.drawText(..., blendBoxLines:)`,  the internal mechanism the components paint with, defaults to false so ordinary text never merges (a `│` inside a log line still overwrites its cell)
- `Divider`/`VerticalDivider`: always merge; negative `indent`/`endIndent` reach into a border row/column and cap with half-arms (`╷` + `─` → `┬`)
- `BoxBorder`: corner cells always merge (overlaid panels tee into the border underneath), edges/titles/backgrounds occlude

## Behavior change
Blending is always on for `Divider`, `VerticalDivider`, and `BoxBorder`, there is no per-component flag. Existing apps change appearance wherever lines overlap:
- Dividers crossing borders/each other now form junctions instead of overwriting.
- An overlaid panel's four corner cells merge with box characters beneath them. Content under the panel is still occluded by its edges, title, and background, but a corner landing exactly on a box char in the underlay (a `│` inside a log line) renders as a junction.
- Bordered boxes with a background color no longer paint that background over their border ring cells (the border pass paints the ring itself).

## Added Example
`dart example/box_line_blending_demo.dart` -  side-by-side `indent: 0` vs `indent: -1`, crossings, mixed-weight tees, and an overlaid panel.