### PR TITLE
Fix Ctrl+C not exiting under the kitty keyboard protocol

### DIFF
--- a/lib/src/binding/terminal_binding.dart
+++ b/lib/src/binding/terminal_binding.dart
@@ -257,10 +257,22 @@ class TerminalBinding extends NoctermBinding
           }
 
           // Route the event through the component tree
-          _routeKeyboardEvent(keyEvent);
+          final handled = _routeKeyboardEvent(keyEvent);
 
-          // Note: Ctrl+C (SIGINT) is routed through the event system first,
-          // allowing components to intercept it. Falls back to shutdown if unhandled.
+          // Ctrl+C is offered to the component tree first so it can be
+          // intercepted, and shuts down when nothing takes it.
+          //
+          // This is not merely a backstop for the SIGINT handler. The kitty
+          // keyboard protocol enabled at startup makes a terminal report
+          // Ctrl+C as an escape sequence instead of the raw 0x03 byte, and
+          // the tty only raises SIGINT for the byte. In any terminal that
+          // supports the protocol - most current ones - this is the only
+          // path that ever sees Ctrl+C.
+          if (!handled && _isCtrlC(keyEvent)) {
+            _performImmediateShutdown();
+            terminal.backend.requestExit(0);
+            return;
+          }
         } else if (event is MouseInputEvent) {
           final mouseEvent = event.event;
 
@@ -486,6 +498,15 @@ class TerminalBinding extends NoctermBinding
       });
     }
   }
+
+  /// Whether [event] is the Ctrl+C that asks the app to quit.
+  ///
+  /// Shift is excluded: terminals conventionally bind Ctrl+Shift+C to copy,
+  /// and the kitty protocol reports the two distinctly.
+  bool _isCtrlC(KeyboardEvent event) =>
+      event.logicalKey == LogicalKey.keyC &&
+      event.modifiers.ctrl &&
+      !event.modifiers.shift;
 
   void _startSignalHandling() {
     // Listen to backend's shutdown stream

--- a/test/binding/ctrl_c_interception_test.dart
+++ b/test/binding/ctrl_c_interception_test.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:nocterm/nocterm.dart';
+import 'package:nocterm/src/backend/terminal.dart' as term;
+import 'package:test/test.dart';
+
+import 'fake_backend.dart';
+
+/// A component that swallows every key it is given.
+class _KeySink extends StatelessComponent {
+  const _KeySink({required this.onKey});
+
+  final bool Function(KeyboardEvent) onKey;
+
+  @override
+  Component build(BuildContext context) {
+    return Focusable(
+      focused: true,
+      onKeyEvent: onKey,
+      child: const SizedBox.shrink(),
+    );
+  }
+}
+
+/// The cases where Ctrl+C must *not* end the app.
+///
+/// These share one binding, which they can because none of them shuts down -
+/// a TerminalBinding registers VM service extensions that cannot be undone,
+/// so only one can exist per isolate. The shutdown case lives in
+/// ctrl_c_shutdown_test.dart for the same reason.
+void main() {
+  late FakeBackend backend;
+  late TerminalBinding binding;
+
+  setUpAll(() {
+    backend = FakeBackend();
+    binding = TerminalBinding(term.Terminal(backend, size: const Size(40, 10)));
+    binding.initialize();
+  });
+
+  tearDownAll(() {
+    backend.dispose();
+    NoctermBinding.resetInstance();
+  });
+
+  Future<void> settle() => Future.delayed(const Duration(milliseconds: 20));
+
+  test(
+      'Given a component that handles Ctrl+C '
+      'when it arrives then the app keeps running', () async {
+    var seen = 0;
+    binding.attachRootComponent(_KeySink(onKey: (_) {
+      seen++;
+      return true;
+    }));
+    await settle();
+
+    backend.sendBytes('\x1b[99;5u'.codeUnits);
+    await settle();
+
+    expect(seen, greaterThan(0), reason: 'the component should see the key');
+    expect(backend.exitRequested, isFalse);
+  });
+
+  test(
+      'Given Ctrl+Shift+C '
+      'when it arrives then the app keeps running', () async {
+    // Terminals bind Ctrl+Shift+C to copy. Under the kitty protocol it is
+    // modifier 6 rather than 5, so the two are distinguishable.
+    binding.attachRootComponent(const SizedBox.shrink());
+    await settle();
+
+    backend.sendBytes('\x1b[99;6u'.codeUnits);
+    await settle();
+
+    expect(backend.exitRequested, isFalse);
+  });
+}

--- a/test/binding/ctrl_c_shutdown_test.dart
+++ b/test/binding/ctrl_c_shutdown_test.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:nocterm/nocterm.dart';
+import 'package:nocterm/src/backend/terminal.dart' as term;
+import 'package:test/test.dart';
+
+import 'fake_backend.dart';
+
+/// The binding pushes the kitty keyboard protocol at startup, so a terminal
+/// that supports it reports Ctrl+C as `ESC[99;5u` rather than the raw 0x03
+/// byte. The tty raises SIGINT only for the byte, so there is no signal to
+/// fall back on: this path is the app's only notice that the user asked to
+/// quit, and it has to shut down on its own.
+///
+/// Only one test here: a TerminalBinding registers VM service extensions,
+/// which cannot be unregistered, so a second binding in the same isolate
+/// throws - and shutting down cancels the input subscription, so a binding
+/// cannot serve two shutdown tests either. The cases that must *not* shut
+/// down share one binding in ctrl_c_interception_test.dart.
+void main() {
+  test(
+      'Given a terminal reporting Ctrl+C as an escape sequence '
+      'when nothing handles it then the app exits', () async {
+    final backend = FakeBackend();
+    final binding =
+        TerminalBinding(term.Terminal(backend, size: const Size(40, 10)));
+    addTearDown(() {
+      backend.dispose();
+      NoctermBinding.resetInstance();
+    });
+
+    binding.initialize();
+    binding.attachRootComponent(const SizedBox.shrink());
+
+    backend.sendBytes('\x1b[99;5u'.codeUnits);
+    await Future.delayed(const Duration(milliseconds: 20));
+
+    expect(backend.exitRequested, isTrue);
+    expect(backend.exitCode, equals(0));
+  });
+}

--- a/test/binding/fake_backend.dart
+++ b/test/binding/fake_backend.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:nocterm/src/backend/terminal_backend.dart';
+import 'package:nocterm/src/size.dart';
+
+/// A backend whose input we drive and whose exit we can observe.
+///
+/// Deliberately has no [shutdownStream]: these tests are about the path
+/// taken when no SIGINT ever arrives.
+class FakeBackend implements TerminalBackend {
+  final _input = StreamController<List<int>>.broadcast();
+  final output = StringBuffer();
+
+  int? exitCode;
+  bool get exitRequested => exitCode != null;
+
+  void sendBytes(List<int> bytes) => _input.add(bytes);
+
+  @override
+  Stream<List<int>>? get inputStream => _input.stream;
+
+  @override
+  void requestExit([int exitCode = 0]) => this.exitCode = exitCode;
+
+  @override
+  void writeRaw(String data) => output.write(data);
+
+  @override
+  Size getSize() => const Size(40, 10);
+
+  @override
+  bool get supportsSize => true;
+
+  @override
+  Stream<Size>? get resizeStream => null;
+
+  @override
+  Stream<void>? get shutdownStream => null;
+
+  @override
+  void enableRawMode() {}
+
+  @override
+  void disableRawMode() {}
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  void notifySizeChanged(Size newSize) {}
+
+  @override
+  void dispose() => _input.close();
+}

--- a/test/input/kitty_keyboard_protocol_test.dart
+++ b/test/input/kitty_keyboard_protocol_test.dart
@@ -465,4 +465,39 @@ void main() {
       expect(event.modifiers.hasAnyModifier, isFalse);
     });
   });
+
+  group('Ctrl+C under the kitty protocol', () {
+    // With the protocol active a terminal reports Ctrl+C as an escape
+    // sequence rather than the raw 0x03 byte. The tty only raises SIGINT
+    // for the byte, so the escape form has to reach the app as an ordinary
+    // Ctrl+C event - it is the only notice the app gets that the user asked
+    // to quit.
+    InputParser parse(List<int> bytes) => InputParser()..addBytes(bytes);
+
+    KeyboardEvent keyEventFor(List<int> bytes) {
+      final event = parse(bytes).parseNext();
+      expect(event, isA<KeyboardInputEvent>());
+      return (event as KeyboardInputEvent).event;
+    }
+
+    test('ESC[99;5u parses as Ctrl+C, same as the raw 0x03 byte', () {
+      final fromEscape = keyEventFor('\x1b[99;5u'.codeUnits);
+      final fromByte = keyEventFor([0x03]);
+
+      expect(fromEscape.logicalKey, equals(LogicalKey.keyC));
+      expect(fromEscape.modifiers.ctrl, isTrue);
+      expect(fromEscape.modifiers.shift, isFalse);
+
+      expect(fromByte.logicalKey, equals(fromEscape.logicalKey));
+      expect(fromByte.modifiers.ctrl, equals(fromEscape.modifiers.ctrl));
+    });
+
+    test('ESC[99;6u is Ctrl+Shift+C and is distinguishable', () {
+      // Terminals bind Ctrl+Shift+C to copy, so it must not read as a quit.
+      final event = keyEventFor('\x1b[99;6u'.codeUnits);
+      expect(event.logicalKey, equals(LogicalKey.keyC));
+      expect(event.modifiers.ctrl, isTrue);
+      expect(event.modifiers.shift, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
Ctrl+C did nothing in most modern terminals. The app could only be killed from another shell.

The binding pushes the kitty keyboard protocol (\x1B[>1u) at startup. A terminal that supports it reports Ctrl+C as ESC[99;5u rather than the raw 0x03 byte, and the tty raises SIGINT only for the byte. So the SIGINT handler (which held the only shutdown fallback) never fired. The key path parsed the event correctly, routed it through the component tree, and discarded the result, two lines below a comment claiming it would fall back to shutdown.

Fix

The key path now shuts down on an unhandled Ctrl+C, as the comment already said it did. Ctrl+Shift+C is excluded (terminals bind it to copy), and the protocol reports the two distinctly.