### PR TITLE
Fix color restoration OSC commands not terminating

### DIFF
--- a/lib/src/backend/terminal.dart
+++ b/lib/src/backend/terminal.dart
@@ -175,8 +175,8 @@ class Terminal {
 
   /// Restore terminal colors to defaults
   void restoreColors() {
-    backend.writeRaw('\x1b]110'); // foreground
-    backend.writeRaw('\x1b]111'); // background
+    backend.writeRaw('\x1b]110\x07'); // foreground
+    backend.writeRaw('\x1b]111\x07'); // background
   }
 
   void reset() {

--- a/lib/src/backend/terminal.dart
+++ b/lib/src/backend/terminal.dart
@@ -175,8 +175,8 @@ class Terminal {
 
   /// Restore terminal colors to defaults
   void restoreColors() {
-    backend.writeRaw('\x1b]110\x07'); // foreground
-    backend.writeRaw('\x1b]111\x07'); // background
+    backend.writeRaw('\x1b]110\x1b\x5c'); // foreground
+    backend.writeRaw('\x1b]111\x1b\x5c'); // background
   }
 
   void reset() {

--- a/test/backend/terminal_test.dart
+++ b/test/backend/terminal_test.dart
@@ -12,7 +12,7 @@ void main() {
 
     expect(
       backend.output.toString(),
-      '\x1b]110\x07\x1b]111\x07',
+      '\x1b]110\x1b\x5c\x1b]111\x1b\x5c',
     );
   });
 }

--- a/test/backend/terminal_test.dart
+++ b/test/backend/terminal_test.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:nocterm/nocterm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('restoreColors terminates each OSC sequence', () {
+    final backend = _RecordingBackend();
+    final terminal = Terminal(backend);
+
+    terminal.restoreColors();
+
+    expect(
+      backend.output.toString(),
+      '\x1b]110\x07\x1b]111\x07',
+    );
+  });
+}
+
+class _RecordingBackend implements TerminalBackend {
+  final output = StringBuffer();
+
+  @override
+  void writeRaw(String data) => output.write(data);
+
+  @override
+  Size getSize() => const Size(80, 24);
+
+  @override
+  bool get supportsSize => true;
+
+  @override
+  Stream<List<int>>? get inputStream => null;
+
+  @override
+  Stream<Size>? get resizeStream => null;
+
+  @override
+  Stream<void>? get shutdownStream => null;
+
+  @override
+  void enableRawMode() {}
+
+  @override
+  void disableRawMode() {}
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  void notifySizeChanged(Size newSize) {}
+
+  @override
+  void requestExit([int exitCode = 0]) {}
+
+  @override
+  void dispose() {}
+}


### PR DESCRIPTION
The OSC commands for restoring foreground and background colors were not terminated. This caused issues like a missing cursor on iTerm2 when the terminal is reset.

OSC commands are terminated with BEL across the library except for these two places, as far as I can tell. This PR adds the standard ECMA-48 terminator to the commands missing it.

A follow up PR could adopt this for the other OSC commands for uniformity.